### PR TITLE
Fixes blank installment after informing invalid brand

### DIFF
--- a/view/frontend/web/js/core/checkout/PaymentMethodController.js
+++ b/view/frontend/web/js/core/checkout/PaymentMethodController.js
@@ -625,8 +625,6 @@ PaymentMethodController.prototype.fillInstallments = function (form) {
         amount = 0;
     }
 
-    form.creditCardInstallments.prop('disabled', true);
-
     var installmentsUrl =
         this.platformConfig.urls.installments + '/' +
         selectedBrand + '/' +
@@ -639,6 +637,9 @@ PaymentMethodController.prototype.fillInstallments = function (form) {
     }).done(function(data) {
         formHandler = new FormHandler();
 
+        if (!data.length) return;
+
+        form.creditCardInstallments.prop('disabled', true);
         formHandler.updateInstallmentSelect(data, form.creditCardInstallments, installmentSelected);
         form.creditCardInstallments.prop('disabled', false);
 

--- a/view/frontend/web/js/core/validators/CreditCardValidator.js
+++ b/view/frontend/web/js/core/validators/CreditCardValidator.js
@@ -77,6 +77,7 @@ CreditCardValidator.prototype.isInputInvalidBrandAvailable = function (element) 
     if (!brands.includes(this.formObject.creditCardBrand.val().toUpperCase())) {
         parentsElements.addClass("_error");
         parentsElements.find(".field-error").show();
+        parentsElements.find(".nobrand").hide();
         return true;
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-57
| **What?**         | Fix the blank installment select behaviour and hides the "no brands configured" message after informing an invalid brand.
| **How?**          | Only updating installments select if the checkout screen receives installment data, and hiding the "no brands configured" message if the informed card brand is invalid.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### :package: Attachments (if appropriate)

After informing a not acceptable brand, the installment dropdown didn't refresh:
![](https://i.imgur.com/BHdPvih.png)

If the user clicks in "Place order" button informing an invalid brand, the "no brands configured" message isn't displayed:
![](https://i.imgur.com/zbIHqlL.png)

#### :speech_balloon: Important guidelines

* Add pull request labels.
* Check base branch.
* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
