### PR TITLE
ci: include sonar and check quality gate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,25 @@
-version: 2
+version: 2.1
+
+_run:
+  pull_sonar_image: &pull_sonar_image
+    name: Pull Docker sonar-scanner image
+    command: |
+      echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+      docker pull pagarme/sonar-scanner
+  pull_sonar_check_quality_gate_image: &pull_sonar_check_quality_gate_image
+    name: Pull Docker check-sonar-quality-gate image
+    command: |
+      echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+      docker pull pagarme/check-sonar-quality-gate
+
+parameters:
+  machine_image:
+    type: string
+    default: ubuntu-2004:202010-01
+  working_dir:
+    type: string
+    default: '~/magento2'
+
 jobs:
   build:
     working_directory: /app
@@ -27,6 +48,33 @@ jobs:
           root: /
           paths:
             - app
+
+  sonar:
+    working_directory: << pipeline.parameters.working_dir >>
+    machine:
+      image: << pipeline.parameters.machine_image >>
+    steps:
+      - checkout
+      - run: *pull_sonar_image
+      - run:
+          name: Run Sonar
+          command: make sonar BRANCH=$CIRCLE_BRANCH
+      - persist_to_workspace:
+          root: << pipeline.parameters.working_dir >>
+          paths:
+            - '*'
+
+  check_quality_gate_sonar:
+    working_directory: << pipeline.parameters.working_dir >>
+    machine:
+      image: << pipeline.parameters.machine_image >>
+    steps:
+      - attach_workspace:
+          at: << pipeline.parameters.working_dir >>
+      - run: *pull_sonar_check_quality_gate_image
+      - run:
+          name: Check quality gate
+          command: make sonar-check-quality-gate
 
   publish:
     working_directory: /
@@ -148,28 +196,43 @@ jobs:
              docker tag ${DOCKER_ACCOUNT}/${PROJECT_NAME} "${DOCKER_ACCOUNT}/${PROJECT_NAME}:${CIRCLE_BRANCH}"
              docker tag ${DOCKER_ACCOUNT}/${PROJECT_NAME} "${DOCKER_ACCOUNT}/${PROJECT_NAME}:${CIRCLE_SHA1:0:8}"
              docker push "${DOCKER_ACCOUNT}/${PROJECT_NAME}"
+
   deploy_staging:
-     machine: true
-     steps:
-       - run:
-           name: Test Swagger
-           command: |
-             response=$(curl -s -o /dev/null -I -w "%{http_code}" http://stg-magento2.mundipagg.com/rest/all/schema?services=all)
-             if [ "$response" = '200' ]; then echo 'Swagger Ok'; else echo 'Swagger invalid'; exit 1; fi
-       - run:
-           name: Send deployment webhook to Rancher
-           command: |
-             BODY='{"push_data":{"tag":"'"${CIRCLE_BRANCH}"'"},"repository":{"repo_name":"'"${DOCKER_ACCOUNT}/${PROJECT_NAME}"'"}}'
-             curl -X POST ${RANCHER_STG_DEPLOY_URL} -H 'Content-Type: application/json' -d "${BODY}"
+    machine:
+      image: << pipeline.parameters.machine_image >>
+    steps:
+      - run:
+          name: Test Swagger
+          command: |
+            response=$(curl -s -o /dev/null -I -w "%{http_code}" http://stg-magento2.mundipagg.com/rest/all/schema?services=all)
+            if [ "$response" = '200' ]; then echo 'Swagger Ok'; else echo 'Swagger invalid'; exit 1; fi
+      - run:
+          name: Send deployment webhook to Rancher
+          command: |
+            BODY='{"push_data":{"tag":"'"${CIRCLE_BRANCH}"'"},"repository":{"repo_name":"'"${DOCKER_ACCOUNT}/${PROJECT_NAME}"'"}}'
+            curl -X POST ${RANCHER_STG_DEPLOY_URL} -H 'Content-Type: application/json' -d "${BODY}"
+
 workflows:
   version: 2
   build_publish_deploy:
     jobs:
       - build
+      - sonar:
+          context: dockerhub
+      - check_quality_gate_sonar:
+          context: dockerhub
+          requires:
+            - sonar
+          filters:
+            branches:
+              ignore:
+                - master
+                - develop
       - publish:
           context: acceptance
           requires:
             - build
+            - sonar
           filters:
               branches:
                   only: develop

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+sonar:
+	docker run -ti -v $(shell pwd):/usr/src/ pagarme/sonar-scanner -Dsonar.branch.name=${BRANCH}
+.PHONY: sonar
+
+sonar-check-quality-gate:
+	docker run -v $(shell pwd):/usr/src/sonar pagarme/check-sonar-quality-gate
+.PHONY: sonar-check-quality-gate

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.organization= pagarme
+sonar.projectKey=magento2
+sonar.projectName=magento2
+sonar.projectVersion=1.0
+sonar.sources=.
+sonar.sourceEncoding=UTF-8
+sonar.exclusions=**/Test/**, **/.circleci/**, **/.github/**


### PR DESCRIPTION
Essa implementação procura configurar o sonar no projeto _magento2_ e torná-lo parte da pipeline do CircleCi.

O Sonar é uma ferramenta que permite medir como está a qualidade do código em desenvolvimento, e isso é feito medindo o coverage, falhas de segurança, linhas duplicadas, etc.

O sonar foi configurado na URL https://sonarcloud.io/dashboard?id=magento2 e necessita de abertura de ticket no amigo para poder ter acesso.

## Alterações feitas

- Incluído job _Sonar_ e adicionado como etapa obrigatória da execução do _Build_.
- Incluído job _check_quality_gate_sonar_ para validar se o quality gate definido está sendo respeitado em novos PRs. Se gate não for respeitado irá quebrar a pipeline. Essa etapa não é etapa obrigatório do build e não executa nas branches long live (master e develop)

## Quality gate definido

Para ver mais sobre quality gate acesse https://mundipagg.atlassian.net/wiki/spaces/PM/pages/1811022419/Quality+Gates

![image](https://user-images.githubusercontent.com/29241659/123113732-2714ac00-d415-11eb-9690-f9992264782a.png)


## Novo fluxo do circleCi

![image](https://user-images.githubusercontent.com/29241659/123113696-1fed9e00-d415-11eb-8df5-a62daf582da8.png)
