### PR TITLE
Adds mundipagg domain to csp whitelist

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="connect-src">
+            <values>
+                <value id="mundipagg-api" type="host">https://api.mundipagg.com</value>
+            </values>
+        </policy>
+        <policy id="img-src">
+            <values>
+                <value id="mundipagg-img" type="host">https://cdn.mundipagg.com</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-159
| **What?**         | Adds mundipagg domain to csp whitelist.
| **Why?**          | Because our domain was being restricted by Content Security Policies.
| **How?**          | Adding our domain to a csp_whitelist.xml file.

**Important Note**

The domains were added in a csp_whitelist.xml file based on the Magento documentation:

https://devdocs.magento.com/guides/v2.4/extension-dev-guide/security/content-security-policies.html#add-a-domain-to-the-whitelist

