### PR TITLE
Fixes charge capture in multistore

### DIFF
--- a/.circleci/data/Dockerfile
+++ b/.circleci/data/Dockerfile
@@ -1,4 +1,4 @@
-FROM yanpantoja/magento2:2.3.6-php7.3
+FROM thiagobarradas/magento2:2.2.0-php7.1
 MAINTAINER Open Source Team
 
 WORKDIR /app

--- a/Controller/Adminhtml/Charges/Cancel.php
+++ b/Controller/Adminhtml/Charges/Cancel.php
@@ -29,6 +29,8 @@ class Cancel extends ChargeAction
             return $this->responseFail($error);
         }
 
+        $this->setWebsiteConfiguration($params['chargeId']);
+
         $amount = str_replace([',', '.'], "", $params['amount']);
         $chargeId = $params['chargeId'];
 

--- a/Controller/Adminhtml/Charges/Capture.php
+++ b/Controller/Adminhtml/Charges/Capture.php
@@ -2,10 +2,8 @@
 
 namespace Pagarme\Pagarme\Controller\Adminhtml\Charges;
 
-use Pagarme\Core\Kernel\Repositories\ChargeRepository;
 use Pagarme\Core\Kernel\Services\ChargeService;
 use Pagarme\Core\Kernel\Services\LogService;
-use Pagarme\Core\Kernel\ValueObjects\Id\ChargeId;
 
 class Capture extends ChargeAction
 {
@@ -30,6 +28,7 @@ class Capture extends ChargeAction
             return $this->responseFail($error);
         }
 
+        $this->setWebsiteConfiguration($params['chargeId']);
         $amount = str_replace([',', '.'], "", $params['amount']);
         $chargeId = $params['chargeId'];
 

--- a/Controller/Adminhtml/Charges/ChargeAction.php
+++ b/Controller/Adminhtml/Charges/ChargeAction.php
@@ -7,6 +7,11 @@ use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
 use Magento\Framework\App\Request\Http;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Store\Model\StoreManagerInterface;
+use Pagarme\Core\Kernel\Repositories\OrderRepository;
+use Pagarme\Core\Kernel\ValueObjects\Id\OrderId;
+use Pagarme\Core\Kernel\Repositories\ChargeRepository;
+use Pagarme\Core\Kernel\ValueObjects\Id\ChargeId;
 
 
 class ChargeAction extends \Magento\Backend\App\Action
@@ -22,12 +27,14 @@ class ChargeAction extends \Magento\Backend\App\Action
     public function __construct(
         Context $context,
         JsonFactory $resultJsonFactory,
-        Http $request
+        Http $request,
+        StoreManagerInterface $storeManager
     ) {
         Magento2CoreSetup::bootstrap();
 
         $this->request = $request;
         $this->resultJsonFactory = $resultJsonFactory;
+        $this->storeManager = $storeManager;
         parent::__construct($context);
     }
 
@@ -38,7 +45,6 @@ class ChargeAction extends \Magento\Backend\App\Action
      */
     public function execute()
     {
-
     }
 
     public function responseSuccess($message)
@@ -62,5 +68,27 @@ class ChargeAction extends \Magento\Backend\App\Action
             ]
         );
         return $json;
+    }
+
+    protected function setWebsiteConfiguration($chargeId)
+    {
+        $chargeRepository = new ChargeRepository();
+
+        $charge = $chargeRepository->findByPagarmeId(
+            new ChargeId($chargeId)
+        );
+
+        $order = (new OrderRepository())->findByPagarmeId(
+            new OrderId($charge->getOrderId()->getValue())
+        );
+
+        $platformOrder = $order->getPlatformOrder();
+        $magentoOrder = $platformOrder->getPlatformOrder();
+
+        $storeId = $magentoOrder->getStore()->getId();
+        $this->storeManager->setCurrentStore($storeId);
+
+        $magento2CoreSetup = new Magento2CoreSetup();
+        $magento2CoreSetup->loadModuleConfigurationFromPlatform();
     }
 }

--- a/Controller/Adminhtml/Hub/Index.php
+++ b/Controller/Adminhtml/Hub/Index.php
@@ -55,10 +55,13 @@ class Index extends \Magento\Backend\App\Action
     public function execute()
     {
         $params = $this->requestObject->getParams();
-        $websiteId = isset($params['website']) 
-            ? $params['website'] 
+        $websiteId = isset($params['website'])
+            ? $params['website']
             : $this->storeManager->getDefaultStoreView()->getWebsiteId();
-        $this->storeManager->setCurrentStore($websiteId);
+
+        $storeId = $this->storeManager->getWebsite($websiteId)
+            ->getDefaultStore()->getId();
+        $this->storeManager->setCurrentStore($storeId);
 
         Magento2CoreSetup::bootstrap();
 

--- a/Model/Api/HubCommand.php
+++ b/Model/Api/HubCommand.php
@@ -56,7 +56,9 @@ class HubCommand implements HubCommandInterface
             ? $paramsFromUrl['websiteId']
             : $this->storeManager->getDefaultStoreView()->getWebsiteId();
 
-        $this->storeManager->setCurrentStore($this->websiteId);
+        $storeId = $this->storeManager->getWebsite($this->websiteId)
+            ->getDefaultStore()->getId();
+        $this->storeManager->setCurrentStore($storeId);
         Magento2CoreSetup::bootstrap();
 
         $hubIntegrationService = new HubIntegrationService();

--- a/view/frontend/web/js/core/checkout/PlatformFormBiding.js
+++ b/view/frontend/web/js/core/checkout/PlatformFormBiding.js
@@ -94,7 +94,9 @@ PlatformConfig.getBrands = function (data, paymentMethodBrands) {
         var brands = Object.keys(paymentMethodBrands);
 
         for (var i = 0, len = brands.length; i < len; i++) {
-            url = data.payment.ccform.icons[brands[i]].url
+            brand = data.payment.ccform.icons[brands[i]];
+            if (!brand) continue;
+            url = brand.url;
             fixArray = [];
             imageUrl = fixArray.concat(url);
 

--- a/view/frontend/web/js/core/checkout/PlatformFormHandler.js
+++ b/view/frontend/web/js/core/checkout/PlatformFormHandler.js
@@ -55,6 +55,7 @@ FormHandler.prototype.fillBrandList = function (brandsObject, formObject) {
     var html = '';
 
     for (var i = 0, len = brandsObject.length; i < len; i++) {
+        if (!brandsObject[i]) continue;
         html +=
             "<li class='item'>" +
             "<img src='" + brandsObject[i].image + "' " +


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-194
| **What?**         | Fixes an issue capturing charges after multistore hub integration, gets the correct store id to install/uninstall a hub integration and only uses brands allowed by module in checkout.
| **Why?**          | To allow the customer to use module correctly with the hub integration.
| **How?**          | Setting the correct store id before capturing/canceling charges and before install/uninstall hub integration. Using only brands that exists in module array.


**Important Notes:**
- This PR also returns Magento 2 version in CI to 2.2.