### PR TITLE
Removes default config if all websites are integrated to hub

### DIFF
--- a/Controller/Adminhtml/Hub/Index.php
+++ b/Controller/Adminhtml/Hub/Index.php
@@ -113,11 +113,11 @@ class Index extends \Magento\Backend\App\Action
             $this->storeManager->setCurrentStore($storeId);
 
             $magento2CoreSetup->loadModuleConfigurationFromPlatform();
-            $actualConfigurations = Magento2CoreSetup::getModuleConfiguration();
+            $currentConfiguration = Magento2CoreSetup::getModuleConfiguration();
 
-            $sameWebsite = $websiteId === intval($currentWebsiteId);
+            $isSameWebsite = $websiteId === intval($currentWebsiteId);
 
-            if (!$sameWebsite && !$actualConfigurations->isHubEnabled()) {
+            if (!$isSameWebsite && !$currentConfiguration->isHubEnabled()) {
                 return false;
             }
         }
@@ -158,32 +158,32 @@ class Index extends \Magento\Backend\App\Action
 
     private function updateStoreFields($websiteId)
     {
-        $actualConfigurations = Magento2CoreSetup::getModuleConfiguration();
+        $currentConfiguration = Magento2CoreSetup::getModuleConfiguration();
 
         $this->configWriter->save(
             "pagarme_pagarme/hub/install_id",
-            $actualConfigurations->getHubInstallId()->getValue(),
+            $currentConfiguration->getHubInstallId()->getValue(),
             'websites',
             $websiteId
         );
 
         $this->configWriter->save(
             "pagarme_pagarme/hub/environment",
-            $actualConfigurations->getHubEnvironment()->getValue(),
+            $currentConfiguration->getHubEnvironment()->getValue(),
             'websites',
             $websiteId
         );
 
         $this->configWriter->save(
             "pagarme_pagarme/global/secret_key",
-            $actualConfigurations->getSecretKey()->getValue(),
+            $currentConfiguration->getSecretKey()->getValue(),
             'websites',
             $websiteId
         );
 
         $this->configWriter->save(
             "pagarme_pagarme/global/public_key",
-            $actualConfigurations->getPublicKey()->getValue(),
+            $currentConfiguration->getPublicKey()->getValue(),
             'websites',
             $websiteId
         );


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-167
| **What?**         | Removes public and secret keys (for test and production envs) only if all magento websites are integrated
| **Why?**          | To remove unused fields from database
| **How?**          |  Checking if all other websites are already integrated when finishing a website integration. In this case, we exclude the fields.