### PR TITLE
Fixes plan handling

### DIFF
--- a/Controller/Adminhtml/Plans/Create.php
+++ b/Controller/Adminhtml/Plans/Create.php
@@ -2,39 +2,13 @@
 
 namespace Pagarme\Pagarme\Controller\Adminhtml\Plans;
 
-use Magento\Backend\App\Action;
-use Magento\Backend\App\Action\Context;
-use Magento\Framework\Registry;
-use Magento\Framework\View\Result\PageFactory;
+
+use Pagarme\Pagarme\Controller\Adminhtml\Plans\PlanAction;
 use Pagarme\Core\Recurrence\Aggregates\Plan;
-use Pagarme\Core\Recurrence\Repositories\PlanRepository;
 use Pagarme\Core\Recurrence\Services\PlanService;
 
-class Create extends Action
+class Create extends PlanAction
 {
-    protected $resultPageFactory = false;
-    /**
-     * @var ProductsPlanFactory
-     */
-    private $productsPlanFactory;
-
-    /**
-     * Constructor
-     *
-     * @param Context $context
-     * @param PageFactory $resultPageFactory
-     * @param Registry $coreRegistry
-     */
-    public function __construct(
-        Context $context,
-        PageFactory $resultPageFactory,
-        Registry $coreRegistry
-    ) {
-        parent::__construct($context);
-        $this->resultPageFactory = $resultPageFactory;
-        $this->coreRegistry = $coreRegistry;
-    }
-
     /**
      * Index action
      *
@@ -43,7 +17,7 @@ class Create extends Action
     public function execute()
     {
         $planId = (int) $this->getRequest()->getParam('id');
-        if($planId) {
+        if ($planId) {
             //@todo this should be a product plan core object
             $planService = new PlanService();
             $planData = $planService->findById($planId);

--- a/Controller/Adminhtml/Plans/Delete.php
+++ b/Controller/Adminhtml/Plans/Delete.php
@@ -2,47 +2,12 @@
 
 namespace Pagarme\Pagarme\Controller\Adminhtml\Plans;
 
-use Magento\Backend\App\Action;
-use Magento\Backend\App\Action\Context;
-use Magento\Framework\Message\Factory;
-use Magento\Framework\Registry;
-use Magento\Framework\View\Result\PageFactory;
+
+use Pagarme\Pagarme\Controller\Adminhtml\Plans\PlanAction;
 use Pagarme\Core\Recurrence\Services\PlanService;
-use Pagarme\Core\Recurrence\Services\ProductSubscriptionService;
-use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
-use Pagarme\Pagarme\Model\ProductsSubscriptionFactory;
 
-class Delete extends Action
+class Delete extends PlanAction
 {
-    protected $resultPageFactory;
-
-    /**
-     * @var Registry
-     */
-    protected $coreRegistry;
-
-    /**
-     * Constructor
-     *
-     * @param \Magento\Backend\App\Action\Context $context
-     * @param \Magento\Framework\View\Result\PageFactory $resultPageFactory
-     * @throws \Exception
-     */
-    public function __construct(
-        \Magento\Backend\App\Action\Context $context,
-        \Magento\Framework\View\Result\PageFactory $resultPageFactory,
-        Registry $coreRegistry,
-        Factory $messageFactory
-    )
-    {
-        $this->resultPageFactory = $resultPageFactory;
-        $this->coreRegistry = $coreRegistry;
-        $this->messageFactory = $messageFactory;
-        Magento2CoreSetup::bootstrap();
-
-        parent::__construct($context);
-    }
-
     /**
      * Index action
      *

--- a/Controller/Adminhtml/Plans/Index.php
+++ b/Controller/Adminhtml/Plans/Index.php
@@ -2,28 +2,10 @@
 
 namespace Pagarme\Pagarme\Controller\Adminhtml\Plans;
 
-use Magento\Backend\App\Action;
-use Magento\Backend\App\Action\Context;
-use Magento\Framework\View\Result\PageFactory;
+use Pagarme\Pagarme\Controller\Adminhtml\Plans\PlanAction;
 
-class Index extends Action
+class Index extends PlanAction
 {
-    protected $resultPageFactory = false;
-
-    /**
-     * Constructor
-     *
-     * @param Context $context
-     * @param PageFactory $resultPageFactory
-     */
-    public function __construct(
-        Context $context,
-        PageFactory $resultPageFactory
-    ) {
-        $this->resultPageFactory = $resultPageFactory;
-        parent::__construct($context);
-    }
-
     /**
      * Index action
      *

--- a/Controller/Adminhtml/Plans/PlanAction.php
+++ b/Controller/Adminhtml/Plans/PlanAction.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Pagarme\Pagarme\Controller\Adminhtml\Plans;
+
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\Registry;
+use Magento\Framework\View\Result\PageFactory;
+use Magento\Framework\Controller\Result\JsonFactory;
+use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
+use Magento\Framework\Message\Factory;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Pagarme\Pagarme\Helper\ProductHelper;
+use Magento\Store\Model\StoreManagerInterface;
+
+class PlanAction extends Action
+{
+
+    protected $resultPageFactory = false;
+    /**
+     * @var CollectionFactory
+     */
+    protected $productCollectionFactory;
+    /**
+     * @var JsonFactory
+     */
+    protected $resultJsonFactory;
+    /**
+     * @var ProductHelper
+     */
+    protected $productHelper;
+    /**
+     * @var Registry
+     */
+    protected $coreRegistry;
+    /**
+     * @var Factory
+     */
+    protected $messageFactory;
+
+
+    /**
+     * Constructor
+     *
+     * @param Context $context
+     * @param PageFactory $resultPageFactory
+     * @param Registry $coreRegistry
+     */
+    public function __construct(
+        Context $context,
+        PageFactory $resultPageFactory,
+        Registry $coreRegistry,
+        Factory $messageFactory,
+        CollectionFactory $productCollectionFactory,
+        JsonFactory $resultJsonFactory,
+        ProductHelper $productHelper,
+        StoreManagerInterface $storeManager
+    ) {
+        parent::__construct($context);
+
+        $this->resultPageFactory = $resultPageFactory;
+        $this->coreRegistry = $coreRegistry;
+        $this->messageFactory = $messageFactory;
+        $this->productHelper = $productHelper;
+        $this->productCollectionFactory = $productCollectionFactory;
+        $this->resultJsonFactory = $resultJsonFactory;
+        $this->storeManager = $storeManager;
+
+        $this->bootstrapDefaultStoreConfigurations();
+    }
+
+    /**
+     * @return \Magento\Framework\Controller\ResultInterface
+     */
+    public function execute()
+    {
+    }
+
+    private function bootstrapDefaultStoreConfigurations()
+    {
+        $defaultStoreId = Magento2CoreSetup::getDefaultStoreId();
+        $this->storeManager->setCurrentStore($defaultStoreId);
+
+        Magento2CoreSetup::bootstrap();
+    }
+}

--- a/Controller/Adminhtml/Plans/SearchProduct.php
+++ b/Controller/Adminhtml/Plans/SearchProduct.php
@@ -2,59 +2,17 @@
 
 namespace Pagarme\Pagarme\Controller\Adminhtml\Plans;
 
-use Magento\Backend\App\Action;
-use Magento\Backend\App\Action\Context;
-use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+
+use Pagarme\Pagarme\Controller\Adminhtml\Plans\PlanAction;
 use Magento\Framework\App\ObjectManager;
-use Magento\Framework\Controller\Result\JsonFactory;
-use Magento\Framework\View\Result\PageFactory;
 use Pagarme\Core\Kernel\Services\MoneyService;
 use Pagarme\Core\Recurrence\Aggregates\Plan;
 use Pagarme\Core\Recurrence\Aggregates\ProductSubscription;
 use Pagarme\Core\Recurrence\Services\PlanService;
 use Pagarme\Core\Recurrence\Services\ProductSubscriptionService;
-use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
-use Pagarme\Pagarme\Helper\ProductHelper;
 
-class SearchProduct extends Action
+class SearchProduct extends PlanAction
 {
-    protected $resultPageFactory = false;
-    /**
-     * @var CollectionFactory
-     */
-    protected $productCollectionFactory;
-    /**
-     * @var JsonFactory
-     */
-    protected $resultJsonFactory;
-    /**
-     * @var ProductHelper
-     */
-    protected $productHelper;
-
-    /**
-     * Constructor
-     *
-     * @param Context $context
-     * @param PageFactory $resultPageFactory
-     * @param CollectionFactory $productCollectionFactory
-     * @param JsonFactory $resultJsonFactory
-     */
-    public function __construct(
-        Context $context,
-        PageFactory $resultPageFactory,
-        CollectionFactory $productCollectionFactory,
-        JsonFactory $resultJsonFactory,
-        ProductHelper $productHelper
-    ) {
-        parent::__construct($context);
-        $this->resultPageFactory = $resultPageFactory;
-        $this->productCollectionFactory = $productCollectionFactory;
-        $this->resultJsonFactory = $resultJsonFactory;
-        $this->productHelper = $productHelper;
-        Magento2CoreSetup::bootstrap();
-    }
-
     /**
      * Index action
      *
@@ -72,7 +30,7 @@ class SearchProduct extends Action
         $product = $objectManager->get('\Magento\Catalog\Model\Product')
             ->load($productId);
 
-        if (empty($product) ) {
+        if (empty($product)) {
             return;
         }
 

--- a/Model/Api/ProductsPlan.php
+++ b/Model/Api/ProductsPlan.php
@@ -27,9 +27,9 @@ class ProductsPlan implements ProductPlanApiInterface
 
     public function __construct(Request $request)
     {
+        Magento2CoreSetup::bootstrap();
         $this->request = $request;
         $this->planService = new PlanService();
-        Magento2CoreSetup::bootstrap();
     }
 
     /**


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-210
| **What?**         | Fixes plan handling (creation, editing and deletion)
| **Why?**          | To allow users to create plans from bundle products
| **How?**          | Changing core's bootstrap position

**Important Notes**
- Was added a  plan action that holds a bootstrap function that forces configuration loading for **default store**.
- Plans also needs permissions to plan item handling, so i've added it, as obrigatory, in magento2 product in hub: https://hub.pagar.me/apps/magento-2/