### PR TITLE
Display admin fields correctly

### DIFF
--- a/etc/adminhtml/system/transaction/creditcard/installments/amex.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/amex.xml
@@ -7,55 +7,55 @@
 -->
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_amex" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="22">
-		<depends>
-			<field id="installments_type">0</field>
+        <depends>
+            <field id="installments_type">0</field>
             <field id="installments_active">1</field>
-		</depends>
-		<label>Installments Amex</label>
-	    <field id="installments_number_amex" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Max number of installments</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-			<comment />
-	        <config_path>payment/pagarme_creditcard/installments_number_amex</config_path>
-	    </field>
-	    <field id="installment_min_amount_amex" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Min installments amount</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installment_min_amount_amex</config_path>
-	    </field>
-	    <field id="installments_interest_by_issuer_amex" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
-	        <label>Enable interest</label>
-	        <comment />
-	        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-	        <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_amex</config_path>
-	    </field>
-	    <field id="installments_interest_rate_initial_amex" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Initial interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_amex</config_path>
+        </depends>
+        <label>Installments Amex</label>
+        <field id="installments_number_amex" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Max number of installments</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_number_amex</config_path>
+        </field>
+        <field id="installment_min_amount_amex" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Min installments amount</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installment_min_amount_amex</config_path>
+        </field>
+        <field id="installments_interest_by_issuer_amex" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
+            <label>Enable interest</label>
+            <comment />
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_amex</config_path>
+        </field>
+        <field id="installments_interest_rate_initial_amex" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Initial interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_amex</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_amex">1</field>
             </depends>
-	    </field>
-	    <field id="installments_interest_rate_incremental_amex" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Incremental interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_amex</config_path>
+        </field>
+        <field id="installments_interest_rate_incremental_amex" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Incremental interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_amex</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_amex">1</field>
             </depends>
-	    </field>
-	    <field id="installments_max_without_interest_amex" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Number of installments without interest</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_max_without_interest_amex</config_path>
+        </field>
+        <field id="installments_max_without_interest_amex" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Number of installments without interest</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_max_without_interest_amex</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_amex">1</field>
             </depends>
-	    </field>
-	</group>
+        </field>
+    </group>
 </include>

--- a/etc/adminhtml/system/transaction/creditcard/installments/amex.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/amex.xml
@@ -9,6 +9,7 @@
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_amex" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="22">
 		<depends>
 			<field id="installments_type">0</field>
+            <field id="installments_active">1</field>
 		</depends>
 		<label>Installments Amex</label>
 	    <field id="installments_number_amex" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">

--- a/etc/adminhtml/system/transaction/creditcard/installments/aura.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/aura.xml
@@ -7,55 +7,55 @@
 -->
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_aura" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
-		<depends>
-			<field id="installments_type">0</field>
+        <depends>
+            <field id="installments_type">0</field>
             <field id="installments_active">1</field>
-		</depends>
-		<label>Installments Aura</label>
-	    <field id="installments_number_aura" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Max number of installments</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_number_aura</config_path>
-	    </field>
-	    <field id="installment_min_amount_aura" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Min installments amount</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installment_min_amount_aura</config_path>
-	    </field>
-	    <field id="installments_interest_by_issuer_aura" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
-	        <label>Enable interest</label>
-	        <comment />
-	        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-	        <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_aura</config_path>
-	    </field>
-	    <field id="installments_interest_rate_initial_aura" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Initial interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_aura</config_path>
+        </depends>
+        <label>Installments Aura</label>
+        <field id="installments_number_aura" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Max number of installments</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_number_aura</config_path>
+        </field>
+        <field id="installment_min_amount_aura" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Min installments amount</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installment_min_amount_aura</config_path>
+        </field>
+        <field id="installments_interest_by_issuer_aura" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
+            <label>Enable interest</label>
+            <comment />
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_aura</config_path>
+        </field>
+        <field id="installments_interest_rate_initial_aura" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Initial interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_aura</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_aura">1</field>
             </depends>
-	    </field>
-	    <field id="installments_interest_rate_incremental_aura" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Incremental interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_aura</config_path>
+        </field>
+        <field id="installments_interest_rate_incremental_aura" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Incremental interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_aura</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_aura">1</field>
             </depends>
-	    </field>
-	    <field id="installments_max_without_interest_aura" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Number of installments without interest</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_max_without_interest_aura</config_path>
+        </field>
+        <field id="installments_max_without_interest_aura" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Number of installments without interest</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_max_without_interest_aura</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_aura">1</field>
             </depends>
-	    </field>
-	</group>
+        </field>
+    </group>
 </include>

--- a/etc/adminhtml/system/transaction/creditcard/installments/aura.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/aura.xml
@@ -9,6 +9,7 @@
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_aura" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
 		<depends>
 			<field id="installments_type">0</field>
+            <field id="installments_active">1</field>
 		</depends>
 		<label>Installments Aura</label>
 	    <field id="installments_number_aura" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">

--- a/etc/adminhtml/system/transaction/creditcard/installments/banese.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/banese.xml
@@ -7,56 +7,56 @@
 -->
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_banese" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
-		<depends>
-			<field id="installments_type">0</field>
+        <depends>
+            <field id="installments_type">0</field>
             <field id="installments_active">1</field>
             <field id="*/*/pagarme_pagarme_global/is_gateway_integration_type">1</field>
-		</depends>
-		<label>Installments Banese</label>
-	    <field id="installments_number_banese" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Max number of installments</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_number_banese</config_path>
-	    </field>
-	    <field id="installment_min_amount_banese" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Min installment amount</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installment_min_amount_banese</config_path>
-	    </field>
-	    <field id="installments_interest_by_issuer_banese" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
-	        <label>Enable interest</label>
-	        <comment />
-	        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-	        <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_banese</config_path>
-	    </field>
-	    <field id="installments_interest_rate_initial_banese" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Initial interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_banese</config_path>
+        </depends>
+        <label>Installments Banese</label>
+        <field id="installments_number_banese" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Max number of installments</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_number_banese</config_path>
+        </field>
+        <field id="installment_min_amount_banese" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Min installment amount</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installment_min_amount_banese</config_path>
+        </field>
+        <field id="installments_interest_by_issuer_banese" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
+            <label>Enable interest</label>
+            <comment />
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_banese</config_path>
+        </field>
+        <field id="installments_interest_rate_initial_banese" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Initial interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_banese</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_banese">1</field>
             </depends>
-	    </field>
-	    <field id="installments_interest_rate_incremental_banese" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Incremental interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_banese</config_path>
+        </field>
+        <field id="installments_interest_rate_incremental_banese" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Incremental interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_banese</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_banese">1</field>
             </depends>
-	    </field>
-	    <field id="installments_max_without_interest_banese" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Number of installments without interest</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_max_without_interest_banese</config_path>
+        </field>
+        <field id="installments_max_without_interest_banese" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Number of installments without interest</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_max_without_interest_banese</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_banese">1</field>
             </depends>
-	    </field>
-	</group>
+        </field>
+    </group>
 </include>

--- a/etc/adminhtml/system/transaction/creditcard/installments/banese.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/banese.xml
@@ -9,6 +9,8 @@
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_banese" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
 		<depends>
 			<field id="installments_type">0</field>
+            <field id="installments_active">1</field>
+            <field id="*/*/pagarme_pagarme_global/is_gateway_integration_type">1</field>
 		</depends>
 		<label>Installments Banese</label>
 	    <field id="installments_number_banese" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">

--- a/etc/adminhtml/system/transaction/creditcard/installments/cabal.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/cabal.xml
@@ -9,6 +9,8 @@
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_cabal" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
 		<depends>
 			<field id="installments_type">0</field>
+            <field id="installments_active">1</field>
+            <field id="*/*/pagarme_pagarme_global/is_gateway_integration_type">1</field>
 		</depends>
 		<label>Installments Cabal</label>
 	    <field id="installments_number_cabal" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">

--- a/etc/adminhtml/system/transaction/creditcard/installments/cabal.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/cabal.xml
@@ -7,56 +7,56 @@
 -->
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_cabal" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
-		<depends>
-			<field id="installments_type">0</field>
+        <depends>
+            <field id="installments_type">0</field>
             <field id="installments_active">1</field>
             <field id="*/*/pagarme_pagarme_global/is_gateway_integration_type">1</field>
-		</depends>
-		<label>Installments Cabal</label>
-	    <field id="installments_number_cabal" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Max number of installments</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_number_cabal</config_path>
-	    </field>
-	    <field id="installment_min_amount_cabal" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Min installment amount</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installment_min_amount_cabal</config_path>
-	    </field>
-	    <field id="installments_interest_by_issuer_cabal" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
-	        <label>Enable interest</label>
-	        <comment />
-	        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-	        <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_cabal</config_path>
-	    </field>
-	    <field id="installments_interest_rate_initial_cabal" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Initial interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_cabal</config_path>
+        </depends>
+        <label>Installments Cabal</label>
+        <field id="installments_number_cabal" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Max number of installments</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_number_cabal</config_path>
+        </field>
+        <field id="installment_min_amount_cabal" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Min installment amount</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installment_min_amount_cabal</config_path>
+        </field>
+        <field id="installments_interest_by_issuer_cabal" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
+            <label>Enable interest</label>
+            <comment />
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_cabal</config_path>
+        </field>
+        <field id="installments_interest_rate_initial_cabal" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Initial interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_cabal</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_cabal">1</field>
             </depends>
-	    </field>
-	    <field id="installments_interest_rate_incremental_cabal" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Incremental interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_cabal</config_path>
+        </field>
+        <field id="installments_interest_rate_incremental_cabal" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Incremental interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_cabal</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_cabal">1</field>
             </depends>
-	    </field>
-	    <field id="installments_max_without_interest_cabal" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Number of installments without interest</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_max_without_interest_cabal</config_path>
+        </field>
+        <field id="installments_max_without_interest_cabal" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Number of installments without interest</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_max_without_interest_cabal</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_cabal">1</field>
             </depends>
-	    </field>
-	</group>
+        </field>
+    </group>
 </include>

--- a/etc/adminhtml/system/transaction/creditcard/installments/credz.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/credz.xml
@@ -7,56 +7,56 @@
 -->
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_credz" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
-		<depends>
-			<field id="installments_type">0</field>
+        <depends>
+            <field id="installments_type">0</field>
             <field id="installments_active">1</field>
             <field id="*/*/pagarme_pagarme_global/is_gateway_integration_type">1</field>
-		</depends>
-		<label>Installments Credz</label>
-	    <field id="installments_number_credz" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Max number of installments</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_number_credz</config_path>
-	    </field>
-	    <field id="installment_min_amount_credz" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Min installment amount</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installment_min_amount_credz</config_path>
-	    </field>
-	    <field id="installments_interest_by_issuer_credz" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
-	        <label>Enable interest</label>
-	        <comment />
-	        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-	        <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_credz</config_path>
-	    </field>
-	    <field id="installments_interest_rate_initial_credz" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Initial interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_credz</config_path>
+        </depends>
+        <label>Installments Credz</label>
+        <field id="installments_number_credz" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Max number of installments</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_number_credz</config_path>
+        </field>
+        <field id="installment_min_amount_credz" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Min installment amount</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installment_min_amount_credz</config_path>
+        </field>
+        <field id="installments_interest_by_issuer_credz" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
+            <label>Enable interest</label>
+            <comment />
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_credz</config_path>
+        </field>
+        <field id="installments_interest_rate_initial_credz" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Initial interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_credz</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_credz">1</field>
             </depends>
-	    </field>
-	    <field id="installments_interest_rate_incremental_credz" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Incremental interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_credz</config_path>
+        </field>
+        <field id="installments_interest_rate_incremental_credz" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Incremental interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_credz</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_credz">1</field>
             </depends>
-	    </field>
-	    <field id="installments_max_without_interest_credz" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Number of installments without interest</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_max_without_interest_credz</config_path>
+        </field>
+        <field id="installments_max_without_interest_credz" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Number of installments without interest</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_max_without_interest_credz</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_credz">1</field>
             </depends>
-	    </field>
-	</group>
+        </field>
+    </group>
 </include>

--- a/etc/adminhtml/system/transaction/creditcard/installments/credz.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/credz.xml
@@ -9,6 +9,8 @@
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_credz" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
 		<depends>
 			<field id="installments_type">0</field>
+            <field id="installments_active">1</field>
+            <field id="*/*/pagarme_pagarme_global/is_gateway_integration_type">1</field>
 		</depends>
 		<label>Installments Credz</label>
 	    <field id="installments_number_credz" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">

--- a/etc/adminhtml/system/transaction/creditcard/installments/diners.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/diners.xml
@@ -9,6 +9,7 @@
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_diners" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="24">
 		<depends>
 			<field id="installments_type">0</field>
+            <field id="installments_active">1</field>
 		</depends>
 		<label>Installments Diners</label>
 	    <field id="installments_number_diners" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">

--- a/etc/adminhtml/system/transaction/creditcard/installments/diners.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/diners.xml
@@ -7,55 +7,55 @@
 -->
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_diners" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="24">
-		<depends>
-			<field id="installments_type">0</field>
+        <depends>
+            <field id="installments_type">0</field>
             <field id="installments_active">1</field>
-		</depends>
-		<label>Installments Diners</label>
-	    <field id="installments_number_diners" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Max number of installments</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_number_diners</config_path>
-	    </field>
-	    <field id="installment_min_amount_diners" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Min installment amount</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installment_min_amount_diners</config_path>
-	    </field>
-	    <field id="installments_interest_by_issuer_diners" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
-	        <label>Enable interest</label>
-	        <comment />
-	        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-	        <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_diners</config_path>
-	    </field>
-	    <field id="installments_interest_rate_initial_diners" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Initial interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_diners</config_path>
+        </depends>
+        <label>Installments Diners</label>
+        <field id="installments_number_diners" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Max number of installments</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_number_diners</config_path>
+        </field>
+        <field id="installment_min_amount_diners" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Min installment amount</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installment_min_amount_diners</config_path>
+        </field>
+        <field id="installments_interest_by_issuer_diners" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
+            <label>Enable interest</label>
+            <comment />
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_diners</config_path>
+        </field>
+        <field id="installments_interest_rate_initial_diners" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Initial interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_diners</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_diners">1</field>
             </depends>
-	    </field>
-	    <field id="installments_interest_rate_incremental_diners" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Incremental interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_diners</config_path>
+        </field>
+        <field id="installments_interest_rate_incremental_diners" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Incremental interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_diners</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_diners">1</field>
             </depends>
-	    </field>
-	    <field id="installments_max_without_interest_diners" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Number of installments without interest</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_max_without_interest_diners</config_path>
+        </field>
+        <field id="installments_max_without_interest_diners" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Number of installments without interest</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_max_without_interest_diners</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_diners">1</field>
             </depends>
-	    </field>
-	</group>
+        </field>
+    </group>
 </include>

--- a/etc/adminhtml/system/transaction/creditcard/installments/discover.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/discover.xml
@@ -9,6 +9,7 @@
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_discover" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
 		<depends>
 			<field id="installments_type">0</field>
+            <field id="installments_active">1</field>
 		</depends>
 		<label>Installments Discover</label>
 	    <field id="installments_number_discover" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">

--- a/etc/adminhtml/system/transaction/creditcard/installments/discover.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/discover.xml
@@ -7,55 +7,55 @@
 -->
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_discover" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
-		<depends>
-			<field id="installments_type">0</field>
+        <depends>
+            <field id="installments_type">0</field>
             <field id="installments_active">1</field>
-		</depends>
-		<label>Installments Discover</label>
-	    <field id="installments_number_discover" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <label>Max number of installments</label>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_number_discover</config_path>
-	    </field>
-	    <field id="installment_min_amount_discover" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <label>Min installment amount</label>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installment_min_amount_discover</config_path>
-	    </field>
-	    <field id="installments_interest_by_issuer_discover" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
-	        <label>Enable interest</label>
-	        <comment />
-	        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-	        <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_discover</config_path>
-	    </field>
-	    <field id="installments_interest_rate_initial_discover" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Initial interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_discover</config_path>
+        </depends>
+        <label>Installments Discover</label>
+        <field id="installments_number_discover" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <label>Max number of installments</label>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_number_discover</config_path>
+        </field>
+        <field id="installment_min_amount_discover" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <label>Min installment amount</label>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installment_min_amount_discover</config_path>
+        </field>
+        <field id="installments_interest_by_issuer_discover" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
+            <label>Enable interest</label>
+            <comment />
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_discover</config_path>
+        </field>
+        <field id="installments_interest_rate_initial_discover" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Initial interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_discover</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_discover">1</field>
             </depends>
-	    </field>
-	    <field id="installments_interest_rate_incremental_discover" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Incremental interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_discover</config_path>
+        </field>
+        <field id="installments_interest_rate_incremental_discover" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Incremental interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_discover</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_discover">1</field>
             </depends>
-	    </field>
-	    <field id="installments_max_without_interest_discover" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Number of installments without interest</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_max_without_interest_discover</config_path>
+        </field>
+        <field id="installments_max_without_interest_discover" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Number of installments without interest</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_max_without_interest_discover</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_discover">1</field>
             </depends>
-	    </field>
-	</group>
+        </field>
+    </group>
 </include>

--- a/etc/adminhtml/system/transaction/creditcard/installments/elo.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/elo.xml
@@ -9,6 +9,7 @@
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_elo" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="25">
 		<depends>
 			<field id="installments_type">0</field>
+            <field id="installments_active">1</field>
 		</depends>
 		<label>Installments Elo</label>
 	    <field id="installments_number_elo" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">

--- a/etc/adminhtml/system/transaction/creditcard/installments/elo.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/elo.xml
@@ -7,55 +7,55 @@
 -->
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_elo" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="25">
-		<depends>
-			<field id="installments_type">0</field>
+        <depends>
+            <field id="installments_type">0</field>
             <field id="installments_active">1</field>
-		</depends>
-		<label>Installments Elo</label>
-	    <field id="installments_number_elo" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Max number of installments</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_number_elo</config_path>
-	    </field>
-	    <field id="installment_min_amount_elo" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Min installment amount</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installment_min_amount_elo</config_path>
-	    </field>
-	    <field id="installments_interest_by_issuer_elo" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
-	        <label>Enable interest</label>
-	        <comment />
-	        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-	        <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_elo</config_path>
-	    </field>
-	    <field id="installments_interest_rate_initial_elo" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Initial interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_elo</config_path>
+        </depends>
+        <label>Installments Elo</label>
+        <field id="installments_number_elo" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Max number of installments</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_number_elo</config_path>
+        </field>
+        <field id="installment_min_amount_elo" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Min installment amount</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installment_min_amount_elo</config_path>
+        </field>
+        <field id="installments_interest_by_issuer_elo" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
+            <label>Enable interest</label>
+            <comment />
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_elo</config_path>
+        </field>
+        <field id="installments_interest_rate_initial_elo" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Initial interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_elo</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_elo">1</field>
             </depends>
-	    </field>
-	    <field id="installments_interest_rate_incremental_elo" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Incremental interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_elo</config_path>
+        </field>
+        <field id="installments_interest_rate_incremental_elo" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Incremental interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_elo</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_elo">1</field>
             </depends>
-	    </field>
-	    <field id="installments_max_without_interest_elo" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Number of installments without interest</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_max_without_interest_elo</config_path>
+        </field>
+        <field id="installments_max_without_interest_elo" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Number of installments without interest</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_max_without_interest_elo</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_elo">1</field>
             </depends>
-	    </field>
-	</group>
+        </field>
+    </group>
 </include>

--- a/etc/adminhtml/system/transaction/creditcard/installments/hipercard.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/hipercard.xml
@@ -7,55 +7,55 @@
 -->
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_hipercard" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="23">
-		<depends>
-			<field id="installments_type">0</field>
+        <depends>
+            <field id="installments_type">0</field>
             <field id="installments_active">1</field>
-		</depends>
-		<label>Installments Hipercard</label>
-	    <field id="installments_number_hipercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Max number of installments</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_number_hipercard</config_path>
-	    </field>
-	    <field id="installment_min_amount_hipercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Min installment amount</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installment_min_amount_hipercard</config_path>
-	    </field>
-	    <field id="installments_interest_by_issuer_hipercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
-	        <label>Enable interest</label>
-	        <comment />
-	        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-	        <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_hipercard</config_path>
-	    </field>
-	    <field id="installments_interest_rate_initial_hipercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Initial interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_hipercard</config_path>
+        </depends>
+        <label>Installments Hipercard</label>
+        <field id="installments_number_hipercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Max number of installments</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_number_hipercard</config_path>
+        </field>
+        <field id="installment_min_amount_hipercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Min installment amount</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installment_min_amount_hipercard</config_path>
+        </field>
+        <field id="installments_interest_by_issuer_hipercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
+            <label>Enable interest</label>
+            <comment />
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_hipercard</config_path>
+        </field>
+        <field id="installments_interest_rate_initial_hipercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Initial interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_hipercard</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_hipercard">1</field>
             </depends>
-	    </field>
-	    <field id="installments_interest_rate_incremental_hipercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Incremental interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_hipercard</config_path>
+        </field>
+        <field id="installments_interest_rate_incremental_hipercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Incremental interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_hipercard</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_hipercard">1</field>
             </depends>
-	    </field>
-	    <field id="installments_max_without_interest_hipercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Number of installments without interest</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_max_without_interest_hipercard</config_path>
+        </field>
+        <field id="installments_max_without_interest_hipercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Number of installments without interest</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_max_without_interest_hipercard</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_hipercard">1</field>
             </depends>
-	    </field>
-	</group>
+        </field>
+    </group>
 </include>

--- a/etc/adminhtml/system/transaction/creditcard/installments/hipercard.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/hipercard.xml
@@ -9,6 +9,7 @@
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_hipercard" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="23">
 		<depends>
 			<field id="installments_type">0</field>
+            <field id="installments_active">1</field>
 		</depends>
 		<label>Installments Hipercard</label>
 	    <field id="installments_number_hipercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">

--- a/etc/adminhtml/system/transaction/creditcard/installments/jcb.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/jcb.xml
@@ -7,55 +7,55 @@
 -->
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_jcb" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
-		<depends>
-			<field id="installments_type">0</field>
+        <depends>
+            <field id="installments_type">0</field>
             <field id="installments_active">1</field>
-		</depends>
-		<label>Installments JCB</label>
-	    <field id="installments_number_jcb" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Max number of installments</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_number_jcb</config_path>
-	    </field>
-	    <field id="installment_min_amount_jcb" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Min installments amount</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installment_min_amount_jcb</config_path>
-	    </field>
-	    <field id="installments_interest_by_issuer_jcb" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
-	        <label>Enable interest</label>
-	        <comment />
-	        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-	        <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_jcb</config_path>
-	    </field>
-	    <field id="installments_interest_rate_initial_jcb" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Initial interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_jcb</config_path>
+        </depends>
+        <label>Installments JCB</label>
+        <field id="installments_number_jcb" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Max number of installments</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_number_jcb</config_path>
+        </field>
+        <field id="installment_min_amount_jcb" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Min installments amount</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installment_min_amount_jcb</config_path>
+        </field>
+        <field id="installments_interest_by_issuer_jcb" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
+            <label>Enable interest</label>
+            <comment />
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_jcb</config_path>
+        </field>
+        <field id="installments_interest_rate_initial_jcb" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Initial interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_jcb</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_jcb">1</field>
             </depends>
-	    </field>
-	    <field id="installments_interest_rate_incremental_jcb" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Incremental interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_jcb</config_path>
+        </field>
+        <field id="installments_interest_rate_incremental_jcb" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Incremental interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_jcb</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_jcb">1</field>
             </depends>
-	    </field>
-	    <field id="installments_max_without_interest_jcb" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Number of installments without interest</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_max_without_interest_jcb</config_path>
+        </field>
+        <field id="installments_max_without_interest_jcb" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Number of installments without interest</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_max_without_interest_jcb</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_jcb">1</field>
             </depends>
-	    </field>
-	</group>
+        </field>
+    </group>
 </include>

--- a/etc/adminhtml/system/transaction/creditcard/installments/jcb.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/jcb.xml
@@ -9,6 +9,7 @@
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_jcb" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
 		<depends>
 			<field id="installments_type">0</field>
+            <field id="installments_active">1</field>
 		</depends>
 		<label>Installments JCB</label>
 	    <field id="installments_number_jcb" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">

--- a/etc/adminhtml/system/transaction/creditcard/installments/mastercard.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/mastercard.xml
@@ -9,6 +9,7 @@
     <group id="pagarme_pagarme_transaction_creditcard_installments" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="21">
 		<depends>
 			<field id="installments_type">0</field>
+            <field id="installments_active">1</field>
 		</depends>
 		<label>Installments Mastercard</label>
 	    <field id="installments_number_mastercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">

--- a/etc/adminhtml/system/transaction/creditcard/installments/mastercard.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/mastercard.xml
@@ -7,55 +7,55 @@
 -->
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="pagarme_pagarme_transaction_creditcard_installments" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="21">
-		<depends>
-			<field id="installments_type">0</field>
+        <depends>
+            <field id="installments_type">0</field>
             <field id="installments_active">1</field>
-		</depends>
-		<label>Installments Mastercard</label>
-	    <field id="installments_number_mastercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Max number of installments</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_number_mastercard</config_path>
-	    </field>
-	    <field id="installment_min_amount_mastercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Min installments amount</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installment_min_amount_mastercard</config_path>
-	    </field>
-	    <field id="installments_interest_by_issuer_mastercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
-	        <label>Enable interest</label>
-	        <comment />
-	        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-	        <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_mastercard</config_path>
-	    </field>
-	    <field id="installments_interest_rate_initial_mastercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Initial interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_mastercard</config_path>
+        </depends>
+        <label>Installments Mastercard</label>
+        <field id="installments_number_mastercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Max number of installments</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_number_mastercard</config_path>
+        </field>
+        <field id="installment_min_amount_mastercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Min installments amount</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installment_min_amount_mastercard</config_path>
+        </field>
+        <field id="installments_interest_by_issuer_mastercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
+            <label>Enable interest</label>
+            <comment />
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_mastercard</config_path>
+        </field>
+        <field id="installments_interest_rate_initial_mastercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Initial interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_mastercard</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_mastercard">1</field>
             </depends>
-	    </field>
-	    <field id="installments_interest_rate_incremental_mastercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Incremental interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_mastercard</config_path>
+        </field>
+        <field id="installments_interest_rate_incremental_mastercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Incremental interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_mastercard</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_mastercard">1</field>
             </depends>
-	    </field>
-	    <field id="installments_max_without_interest_mastercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Number of installments without interest</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_max_without_interest_mastercard</config_path>
+        </field>
+        <field id="installments_max_without_interest_mastercard" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Number of installments without interest</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_max_without_interest_mastercard</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_mastercard">1</field>
             </depends>
-	    </field>
-	</group>
+        </field>
+    </group>
 </include>

--- a/etc/adminhtml/system/transaction/creditcard/installments/visa.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/visa.xml
@@ -9,6 +9,7 @@
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_visa" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
 		<depends>
 			<field id="installments_type">0</field>
+            <field id="installments_active">1</field>
 		</depends>
 		<label>Installments Visa</label>
 	    <field id="installments_number_visa" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">

--- a/etc/adminhtml/system/transaction/creditcard/installments/visa.xml
+++ b/etc/adminhtml/system/transaction/creditcard/installments/visa.xml
@@ -7,55 +7,55 @@
 -->
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="pagarme_pagarme_transaction_creditcard_installments_mastercard_visa" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
-		<depends>
-			<field id="installments_type">0</field>
+        <depends>
+            <field id="installments_type">0</field>
             <field id="installments_active">1</field>
-		</depends>
-		<label>Installments Visa</label>
-	    <field id="installments_number_visa" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Max number of installments</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_number_visa</config_path>
-	    </field>
-	    <field id="installment_min_amount_visa" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Min installment amount</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installment_min_amount_visa</config_path>
-	    </field>
-	    <field id="installments_interest_by_issuer_visa" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
-	        <label>Enable interest</label>
-	        <comment />
-	        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-	        <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_visa</config_path>
-	    </field>
-	    <field id="installments_interest_rate_initial_visa" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Initial interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_visa</config_path>
+        </depends>
+        <label>Installments Visa</label>
+        <field id="installments_number_visa" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Max number of installments</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_number_visa</config_path>
+        </field>
+        <field id="installment_min_amount_visa" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Min installment amount</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installment_min_amount_visa</config_path>
+        </field>
+        <field id="installments_interest_by_issuer_visa" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select">
+            <label>Enable interest</label>
+            <comment />
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/pagarme_creditcard/installments_interest_by_issuer_visa</config_path>
+        </field>
+        <field id="installments_interest_rate_initial_visa" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Initial interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_initial_visa</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_visa">1</field>
             </depends>
-	    </field>
-	    <field id="installments_interest_rate_incremental_visa" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Incremental interest rate (%)</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_visa</config_path>
+        </field>
+        <field id="installments_interest_rate_incremental_visa" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Incremental interest rate (%)</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_interest_rate_incremental_visa</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_visa">1</field>
             </depends>
-	    </field>
-	    <field id="installments_max_without_interest_visa" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
-	        <label>Number of installments without interest</label>
-			<backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
-	        <comment />
-	        <config_path>payment/pagarme_creditcard/installments_max_without_interest_visa</config_path>
+        </field>
+        <field id="installments_max_without_interest_visa" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+            <label>Number of installments without interest</label>
+            <backend_model>Pagarme\Pagarme\Model\Validation\GenericValidation</backend_model>
+            <comment />
+            <config_path>payment/pagarme_creditcard/installments_max_without_interest_visa</config_path>
             <depends>
                 <field id="installments_interest_by_issuer_visa">1</field>
             </depends>
-	    </field>
-	</group>
+        </field>
+    </group>
 </include>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-213
| **What?**         | Hide and display fields correctly.
| **Why?**          | Because the settings are different for PSP and Gateway clients.
| **How?**          | Adding magento depends tag.


• Before change

![image](https://user-images.githubusercontent.com/41760474/125679684-1ca0a441-99de-4aa7-818f-8c7d5384b77c.png)


• After changes

![installment2](https://user-images.githubusercontent.com/41760474/125679721-c6dabc29-927e-4797-9eca-6eb0401f7d9b.png)


![installment1](https://user-images.githubusercontent.com/41760474/125679737-77bde998-9284-465c-9467-d5938262b02a.png)
