### PR TITLE
Send to staging ecommerce module core on developer branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,8 @@ jobs:
             docker exec -it newimage sh -c "cd /var/www/html && rm composer.lock"
             docker exec -it newimage sh -c "cd /var/www/html && composer selfupdate 1.10.22"
             docker exec -it newimage sh -c "cd /var/www/html && composer require pagarme/pagarme-magento2-module:dev-develop -vvv"
+            docker exec -it newimage sh -c "cd /var/www/html && composer remove pagarme/ecommerce-module-core"
+            docker exec -it newimage sh -c "cd /var/www/html && composer require pagarme/ecommerce-module-core:dev-develop -vvv"
             docker exec -it newimage sh -c "cd /var/www/html && composer update -vvv"
             docker exec -it newimage sh -c "cd /var/www/ && find html/ -type d -exec chmod 775 {} \;"
             docker exec -it newimage sh -c "cd /var/www/ && find html/ -type f -exec chmod 664 {} \;"

--- a/.circleci/data/Dockerfile
+++ b/.circleci/data/Dockerfile
@@ -1,4 +1,4 @@
-FROM thiagobarradas/magento2:2.2.0-php7.1
+FROM thiagobarradas/magento2:2.3.0-php7.1
 MAINTAINER Open Source Team
 
 WORKDIR /app


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-265
| **What?**         | Send to staging ecommerce module core in developer branch
| **Why?**          | To mantain the magento 2 staging with the ecommerce-module-core in developer version


