### PR TITLE
Added translations for ACL and menu items in Adminhtml

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -3,17 +3,17 @@
 	<acl>
 		<resources>
 			<resource id="Magento_Backend::admin">
-				<resource id="Pagarme_Pagarme::Charges" sortOrder="10" title="Charges">
-					<resource id="Pagarme_Pagarme::Charges_save" sortOrder="10" title="Save Charges"/>
-					<resource id="Pagarme_Pagarme::Charges_delete" sortOrder="20" title="Delete Charges"/>
-					<resource id="Pagarme_Pagarme::Charges_update" sortOrder="30" title="Update Charges"/>
-					<resource id="Pagarme_Pagarme::Charges_view" sortOrder="40" title="View Charges"/>
+				<resource id="Pagarme_Pagarme::Charges" sortOrder="10" title="Charges" translate="title">
+					<resource id="Pagarme_Pagarme::Charges_save" sortOrder="10" title="Save Charges" translate="title" />
+					<resource id="Pagarme_Pagarme::Charges_delete" sortOrder="20" title="Delete Charges" translate="title" />
+					<resource id="Pagarme_Pagarme::Charges_update" sortOrder="30" title="Update Charges" translate="title" />
+					<resource id="Pagarme_Pagarme::Charges_view" sortOrder="40" title="View Charges" translate="title" />
 				</resource>
-				<resource id="Pagarme_Pagarme::Cards" sortOrder="10" title="Cards">
-					<resource id="Pagarme_Pagarme::Cards_save" sortOrder="10" title="Save Cards"/>
-					<resource id="Pagarme_Pagarme::Cards_delete" sortOrder="20" title="Delete Cards"/>
-					<resource id="Pagarme_Pagarme::Cards_update" sortOrder="30" title="Update Cards"/>
-					<resource id="Pagarme_Pagarme::Cards_view" sortOrder="40" title="View Cards"/>
+				<resource id="Pagarme_Pagarme::Cards" sortOrder="10" title="Cards" translate="title">
+					<resource id="Pagarme_Pagarme::Cards_save" sortOrder="10" title="Save Cards" translate="title" />
+					<resource id="Pagarme_Pagarme::Cards_delete" sortOrder="20" title="Delete Cards" translate="title" />
+					<resource id="Pagarme_Pagarme::Cards_update" sortOrder="30" title="Update Cards" translate="title" />
+					<resource id="Pagarme_Pagarme::Cards_view" sortOrder="40" title="View Cards" translate="title" />
 				</resource>
 			</resource>
 		</resources>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -2,14 +2,14 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
 	<menu>
 		<add id="Pagarme::top_level" module="Pagarme_Pagarme" resource="Magento_Backend::content" sortOrder="9999" title="Pagar.me"/>
-		<add id="Pagarme::pagarme_pagarme_label" module="Pagarme_Pagarme" parent="Pagarme::top_level" resource="Magento_Config::config" sortOrder="1" title="Configurations"/>
-		<add action="pagarme_pagarme/charges/index" id="Pagarme::pagarme_pagarme_charges" module="Pagarme_Pagarme" parent="Pagarme::pagarme_pagarme_label" resource="Magento_Backend::content" sortOrder="20" title="Charges Pagar.me"/>
-		<add action="pagarme_pagarme/cards/index" id="Pagarme::pagarme_pagarme_cards" module="Pagarme_Pagarme" parent="Pagarme::pagarme_pagarme_label" resource="Magento_Backend::content" sortOrder="10" title="Cards Pagar.me"/>
-		<add action="adminhtml/system_config/edit/section/payment" id="Pagarme::pagarme_pagarme_payment_methods" module="Pagarme_Pagarme" parent="Pagarme::pagarme_pagarme_label" resource="Magento_Config::config" sortOrder="1" title="Payment Methods"/>
+		<add id="Pagarme::pagarme_pagarme_label" module="Pagarme_Pagarme" parent="Pagarme::top_level" resource="Magento_Config::config" sortOrder="1" title="Configurations" translate="title" />
+		<add action="pagarme_pagarme/charges/index" id="Pagarme::pagarme_pagarme_charges" module="Pagarme_Pagarme" parent="Pagarme::pagarme_pagarme_label" resource="Magento_Backend::content" sortOrder="20" title="Charges Pagar.me" translate="title" />
+		<add action="pagarme_pagarme/cards/index" id="Pagarme::pagarme_pagarme_cards" module="Pagarme_Pagarme" parent="Pagarme::pagarme_pagarme_label" resource="Magento_Backend::content" sortOrder="10" title="Cards Pagar.me" translate="title" />
+		<add action="adminhtml/system_config/edit/section/payment" id="Pagarme::pagarme_pagarme_payment_methods" module="Pagarme_Pagarme" parent="Pagarme::pagarme_pagarme_label" resource="Magento_Config::config" sortOrder="1" title="Payment Methods" translate="title" />
 
-		<add id="Pagarme::pagarme_pagarme_recurrence" module="Pagarme_Pagarme" parent="Pagarme::top_level" resource="Magento_Config::config" sortOrder="30" title="Recurrence"/>
-		<add action="pagarme_pagarme/recurrenceproducts/index" id="Pagarme::pagarme_pagarme_recurrenceproducts_index" module="Pagarme_Pagarme" parent="Pagarme::pagarme_pagarme_recurrence" resource="Magento_Config::config" sortOrder="1" title="Recurrence Products"/>
-		<add action="pagarme_pagarme/plans/index" id="Pagarme::pagarme_pagarme_plans_index" module="Pagarme_Pagarme" parent="Pagarme::pagarme_pagarme_recurrence" resource="Magento_Config::config" sortOrder="1" title="Plans"/>
-		<add action="pagarme_pagarme/subscriptions/index" id="Pagarme::pagarme_pagarme_subscriptions_index" module="Pagarme_Pagarme" parent="Pagarme::pagarme_pagarme_recurrence" resource="Magento_Config::config" sortOrder="1" title="Subscriptions"/>
+		<add id="Pagarme::pagarme_pagarme_recurrence" module="Pagarme_Pagarme" parent="Pagarme::top_level" resource="Magento_Config::config" sortOrder="30" title="Recurrence" translate="title" />
+		<add action="pagarme_pagarme/recurrenceproducts/index" id="Pagarme::pagarme_pagarme_recurrenceproducts_index" module="Pagarme_Pagarme" parent="Pagarme::pagarme_pagarme_recurrence" resource="Magento_Config::config" sortOrder="1" title="Recurrence Products" translate="title" />
+		<add action="pagarme_pagarme/plans/index" id="Pagarme::pagarme_pagarme_plans_index" module="Pagarme_Pagarme" parent="Pagarme::pagarme_pagarme_recurrence" resource="Magento_Config::config" sortOrder="1" title="Plans" translate="title" />
+		<add action="pagarme_pagarme/subscriptions/index" id="Pagarme::pagarme_pagarme_subscriptions_index" module="Pagarme_Pagarme" parent="Pagarme::pagarme_pagarme_recurrence" resource="Magento_Config::config" sortOrder="1" title="Subscriptions" translate="title" />
 	</menu>
 </config>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **What?**         | Added translations attribute for ACL and menu item titles
| **Why?**          | Preventing un-translated items for another Admin Locale as en_US, ex. es_ES
| **How?**          | Added fixes in XML files 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->