### PR TITLE
Hides marketplace option

### DIFF
--- a/etc/adminhtml/system/marketplace.xml
+++ b/etc/adminhtml/system/marketplace.xml
@@ -45,5 +45,8 @@
                 <field id="active">1</field>
             </depends>
         </field>
+        <depends>
+            <field id="*/*/pagarme_pagarme_global/is_gateway_integration_type">1</field>
+        </depends>
     </group>
 </include>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOP-465
| **What?**         | Shows marketplace option only when advanced settings is enabled.
| **Why?**          | Because only Gateway customers will use it.
| **How?**          | Verifying if advanced settings is enabled before showing marketplace fields.

When "advanced settings" is disabled:

![](https://i.imgur.com/dcsEy77.jpg)

When "advanced settings" is enabled:

![](https://i.imgur.com/e3y6jzB.jpg)