### PR TITLE
Correcao responsivo layout cartao

### DIFF
--- a/view/frontend/web/template/payment/creditcard-form.html
+++ b/view/frontend/web/template/payment/creditcard-form.html
@@ -7,7 +7,7 @@
             <div class="field no-label">
                 <div class="control">
                     <select name="payment[cc_saved_creditcards]"
-                            style="width: 335px;"
+                            style="width: 100%;"
                             class="select cc_saved_creditcards"
                     ></select>
                 </div>
@@ -43,7 +43,7 @@
     <div class="control">
         <input type="text"
                autocomplete="off"
-               style="width: 225px;"
+               style="width: 100%;"
                class="input-text cc_amount"
                name="payment[cc_amount]"
                value=""
@@ -77,7 +77,7 @@
     <div class="control">
         <input type="text"
                autocomplete="off"
-               style="width: 225px;"
+               style="width: 100%;"
                class="input-text cc_owner"
                maxlength="40"
                name="payment[cc_owner]"
@@ -154,7 +154,7 @@
             <div class="field no-label installments">
                 <div class="control">
                     <select name="payment[cc_installments]"
-                             style="width: 335px;"
+                             style="width: 100%;"
                              class="select select-installments cc_installments"
                     >
                     </select>


### PR DESCRIPTION
No checkout, principalmente quando utilizado checkout one step checkout, na visão mobile o layout fica "quebrado", deixando em % fica correto pois se adapta a dimensão da DIV anterior.