### PR TITLE
PAOPN-262: replacement of strlen and substr methods in softdescription

### DIFF
--- a/Model/PagarmeConfigProvider.php
+++ b/Model/PagarmeConfigProvider.php
@@ -102,9 +102,9 @@ class PagarmeConfigProvider implements ConfigProviderInterface
 
         if (
             $isGatewayIntegrationType
-            && strlen($softDescription) > $maxSizeForGateway
+            && mb_trlen($softDescription) > $maxSizeForGateway
         ) {
-            $newResult = substr($softDescription, 0, $maxSizeForGateway);
+            $newResult = mb_substr($softDescription, 0, $maxSizeForGateway);
             $this->config->saveConfig(
                 self::XML_PATH_SOFT_DESCRIPTION,
                 $newResult,
@@ -117,9 +117,9 @@ class PagarmeConfigProvider implements ConfigProviderInterface
 
         if (
             !$isGatewayIntegrationType
-            && strlen($softDescription) > $maxSizeForPSP
+            && mb_strlen($softDescription) > $maxSizeForPSP
         ) {
-            $newResult = substr($softDescription, 0, $maxSizeForPSP);
+            $newResult = mb_substr($softDescription, 0, $maxSizeForPSP);
             $this->config->saveConfig(
                 self::XML_PATH_SOFT_DESCRIPTION,
                 $newResult,

--- a/Model/PagarmeConfigProvider.php
+++ b/Model/PagarmeConfigProvider.php
@@ -102,7 +102,7 @@ class PagarmeConfigProvider implements ConfigProviderInterface
 
         if (
             $isGatewayIntegrationType
-            && mb_trlen($softDescription) > $maxSizeForGateway
+            && mb_strlen($softDescription) > $maxSizeForGateway
         ) {
             $newResult = mb_substr($softDescription, 0, $maxSizeForGateway);
             $this->config->saveConfig(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-254
| **What?**         | make the correct character count.
| **Why?**          | character count is considering characters with accent as 2 characters, it should count as 1
| **How?**          | I changed the method used to count characters from 'strlen' to 'mb_strlen'
