### PR TITLE
PAOPN-262: replacement of strlen and substr methods in softdescription

### DIFF
--- a/Model/PagarmeConfigProvider.php
+++ b/Model/PagarmeConfigProvider.php
@@ -102,7 +102,7 @@ class PagarmeConfigProvider implements ConfigProviderInterface
 
         if (
             $isGatewayIntegrationType
-            && mb_trlen($softDescription) > $maxSizeForGateway
+            && mb_strlen($softDescription) > $maxSizeForGateway
         ) {
             $newResult = mb_substr($softDescription, 0, $maxSizeForGateway);
             $this->config->saveConfig(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-262
| **What?**         | make the correct character count.
| **Why?**          | character count is considering characters with accent as 2 characters, it should count as 1
| **How?**          | I changed the method used to count characters from 'strlen' to 'mb_strlen'

