### PR TITLE
PAOPN-265: removed .bind() method which was deprecated in jquery vers…

### DIFF
--- a/view/frontend/web/js/core/checkout/PaymentMethodController.js
+++ b/view/frontend/web/js/core/checkout/PaymentMethodController.js
@@ -395,7 +395,7 @@ PaymentMethodController.prototype.addCreditCardNumberListener = function(formObj
         setTimeout(function() {
             paymentMethodController.setBin(binObj,  element, formObject);
         }, 300);
-    }).bind(this);
+    });
 };
 
 PaymentMethodController.prototype.twoCardsTotal = function (paymentMethod) {


### PR DESCRIPTION
…ion 3.0

| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-265
| **What?**         | Error when selecting billet/card in multi-means option
| **Why?**          | For the billet/card multi-means option to work correctly
| **How?**          | removed .bind() method which was deprecated in jquery version 3.0
