### PR TITLE
Bugfix/paopn 279/error when editing customer in adm portal

### DIFF
--- a/Observer/AdminCustomerBeforeSave.php
+++ b/Observer/AdminCustomerBeforeSave.php
@@ -44,7 +44,6 @@ class AdminCustomerBeforeSave implements ObserverInterface
         }
 
         $event = $observer->getEvent();
-
         $platformCustomer = new Magento2PlatformCustomerDecorator($event->getCustomer());
 
         if (empty($platformCustomer->getPagarmeId())) {
@@ -56,7 +55,7 @@ class AdminCustomerBeforeSave implements ObserverInterface
             $customerService->updateCustomerAtPagarme($platformCustomer);
         } catch (\Exception $exception) {
             $log = new LogService('CustomerService');
-            $log->info("ola" . $exception->getMessage());
+            $log->info($exception->getMessage());
 
             if ($exception->getCode() == 404) {
                 $log->info(

--- a/Observer/AdminCustomerBeforeSave.php
+++ b/Observer/AdminCustomerBeforeSave.php
@@ -44,14 +44,19 @@ class AdminCustomerBeforeSave implements ObserverInterface
         }
 
         $event = $observer->getEvent();
+
         $platformCustomer = new Magento2PlatformCustomerDecorator($event->getCustomer());
+
+        if (empty($platformCustomer->getPagarmeId())) {
+            return $this;
+        }
 
         $customerService = new CustomerService();
         try {
             $customerService->updateCustomerAtPagarme($platformCustomer);
         } catch (\Exception $exception) {
             $log = new LogService('CustomerService');
-            $log->info($exception->getMessage());
+            $log->info("ola" . $exception->getMessage());
 
             if ($exception->getCode() == 404) {
                 $log->info(

--- a/Observer/AdminCustomerBeforeSave.php
+++ b/Observer/AdminCustomerBeforeSave.php
@@ -51,7 +51,7 @@ class AdminCustomerBeforeSave implements ObserverInterface
             $customerService->updateCustomerAtPagarme($platformCustomer);
         } catch (\Exception $exception) {
             $log = new LogService('CustomerService');
-            $log->info($exception->getResponseBody());
+            $log->info($exception->getMessage());
 
             if ($exception->getCode() == 404) {
                 $log->info(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-279
| **What?**         | Error when creating/editing customer data through the administrative portal.
| **Why?**          | Why do you need this implementation/fix?
| **How?**          | Check if the customer already exists at Pagar.Me, if it already exists, perform the validation ignoring the 'document' field if it is blank, if it does not exist, do not validate the customer data with Pagar.Me