### PR TITLE
PAOPN-284: removed '.selector' function which is deprecated in jQuery 3

### DIFF
--- a/view/frontend/web/js/core/checkout/PaymentMethodController.js
+++ b/view/frontend/web/js/core/checkout/PaymentMethodController.js
@@ -399,8 +399,8 @@ PaymentMethodController.prototype.addCreditCardNumberListener = function(formObj
 };
 
 PaymentMethodController.prototype.twoCardsTotal = function (paymentMethod) {
-    var card1 = paymentMethod.formObject[0].creditCardInstallments.selector;
-    var card2 = paymentMethod.formObject[1].creditCardInstallments.selector;
+    var card1 = paymentMethod.formObject[0].creditCardInstallments;
+    var card2 = paymentMethod.formObject[1].creditCardInstallments;
 
     var totalCard1 = paymentMethod.formObject[0].inputAmount.val().replace(platformConfig.currency.decimalSeparator, ".");
     var totalCard2 = paymentMethod.formObject[1].inputAmount.val().replace(platformConfig.currency.decimalSeparator, ".");
@@ -418,7 +418,7 @@ PaymentMethodController.prototype.twoCardsTotal = function (paymentMethod) {
 }
 
 PaymentMethodController.prototype.boletoCreditCardTotal = function (paymentMethod) {
-    var cardElement = paymentMethod.formObject[1].creditCardInstallments.selector;
+    var cardElement = paymentMethod.formObject[1].creditCardInstallments;
 
     var sumInterestTotal = jQuery(cardElement).find(":selected").attr("interest");
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-284
| **What?**         | Order summary resets the total amount when selecting one of the multi-means payment methods.
| **Why?**          | To view the total amount of the order on the screen after changing the payment method
| **How?**          | Removed '.selector' function which is deprecated in jQuery 3.
