### PR TITLE
Remove .selector because it's removed from JQuery3

### DIFF
--- a/view/frontend/web/js/core/checkout/PaymentMethodController.js
+++ b/view/frontend/web/js/core/checkout/PaymentMethodController.js
@@ -473,7 +473,7 @@ PaymentMethodController.prototype.addCreditCardInstallmentsListener = function (
 PaymentMethodController.prototype.addSavedCreditCardsListener = function(formObject) {
 
     var paymentMethodController = this;
-    var selector = formObject.savedCreditCardSelect.selector;
+    var selector = formObject.savedCreditCardSelect;
     var brand = jQuery(selector + ' option:selected').attr('brand');
 
     if (brand == undefined) {
@@ -755,9 +755,9 @@ PaymentMethodController.prototype.fillSavedCreditCardsSelect = function (formObj
     formHandler.init(formObject);
     formHandler.fillSavedCreditCardsSelect(platformConfig, formObject);
 
-    if (typeof formObject.savedCreditCardSelect.selector != 'undefined') {
+    if (typeof formObject.savedCreditCardSelect != 'undefined') {
 
-        selector = formObject.savedCreditCardSelect.selector;
+        selector = formObject.savedCreditCardSelect;
         var brand = jQuery(selector + ' option:selected').attr('brand');
 
         if (brand == undefined) {
@@ -791,7 +791,7 @@ PaymentMethodController.prototype.removeMultibuyerForm = function (formObject) {
 };
 
 PaymentMethodController.prototype.addShowMultibuyerListener = function(formObject) {
-    jQuery(formObject.multibuyer.showMultibuyer.selector).on('click', function () {
+    jQuery(formObject.multibuyer.showMultibuyer).on('click', function () {
         formHandler.init(formObject);
         formHandler.toggleMultibuyer(formObject);
     });


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-286
| **What?**         | Remove .selector 
| **Why?**          | .selector is deprecated in 1.7 and removed in version 3
| **How?**          | Remove .selector 


* [JQuery Documentation](https://api.jquery.com/selector/)
