### PR TITLE
remove array_flip because it is not necessary

### DIFF
--- a/Observer/PaymentMethodAvailable.php
+++ b/Observer/PaymentMethodAvailable.php
@@ -114,21 +114,19 @@ class PaymentMethodAvailable implements ObserverInterface
             return $pagarmePaymentsMethods;
         }
 
-        $pagarmePaymentsMethodsFlip = array_flip($pagarmePaymentsMethods);
-
         $methodsAvailable = [];
         foreach ($recurrenceProducts as $recurrenceProduct) {
 
             if (
                 $recurrenceProduct->getCreditCard() &&
-                in_array('pagarme_creditcard', $pagarmePaymentsMethodsFlip)
+                in_array('pagarme_creditcard', $pagarmePaymentsMethods)
             ) {
                 $methodsAvailable[] = 'pagarme_creditcard';
             }
 
             if (
                 $recurrenceProduct->getBoleto() &&
-                in_array('pagarme_billet', $pagarmePaymentsMethodsFlip)
+                in_array('pagarme_billet', $pagarmePaymentsMethods)
             ) {
                 $methodsAvailable[] = 'pagarme_billet';
             }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-285
| **What?**         | Bug fix of not displaying payment methods at checkout when using recurring products
| **Why?**          | Fix needed to display payment methods when recurring product
| **How?**          | Remove array_flip because it is not needed and in version 8+ it generates a problem.