### PR TITLE
Adjusting compatibility between php 7 and php 8

### DIFF
--- a/Block/Payment/Billet.php
+++ b/Block/Payment/Billet.php
@@ -94,7 +94,10 @@ class Billet extends Template
     private function getBoletoLinkFromOrder($info)
     {
         $lastTransId = $info->getLastTransId();
-        $orderId = substr($lastTransId, 0, 19);
+        $orderId = null;
+        if ($lastTransId) {
+            $orderId = substr($lastTransId, 0, 19);
+        }
 
         if (!$orderId) {
             return null;

--- a/Block/Payment/Info/Billet.php
+++ b/Block/Payment/Info/Billet.php
@@ -70,7 +70,10 @@ class Billet extends Info
     private function getBoletoLinkFromOrder($info)
     {
         $lastTransId = $info->getLastTransId();
-        $orderId = substr($lastTransId, 0, 19);
+        $orderId = null;
+        if ($lastTransId) {
+            $orderId = substr($lastTransId, 0, 19);
+        }
 
         if (!$orderId) {
             return null;

--- a/Block/Payment/Info/BilletCreditCard.php
+++ b/Block/Payment/Info/BilletCreditCard.php
@@ -94,7 +94,10 @@ class BilletCreditCard extends Cc
         Magento2CoreSetup::bootstrap();
 
         $lastTransId = $info->getLastTransId();
-        $orderId = substr($lastTransId, 0, 19);
+        $orderId = null;
+        if ($lastTransId) {
+            $orderId = substr($lastTransId, 0, 19);
+        }
 
         $orderRepository = new OrderRepository();
         $order = $orderRepository->findByPagarmeId(new OrderId($orderId));
@@ -131,7 +134,10 @@ class BilletCreditCard extends Cc
     private function getBoletoLinkFromOrder($info)
     {
         $lastTransId = $info->getLastTransId();
-        $orderId = substr($lastTransId, 0, 19);
+        $orderId = null;
+        if ($lastTransId) {
+            $orderId = substr($lastTransId, 0, 19);
+        }
 
         if (!$orderId) {
             return null;

--- a/Block/Payment/Info/Pix.php
+++ b/Block/Payment/Info/Pix.php
@@ -34,7 +34,10 @@ class Pix extends Info
         }
 
         $lastTransId = $info->getLastTransId();
-        $orderId = substr($lastTransId, 0, 19);
+        $orderId = null;
+        if ($lastTransId) {
+            $orderId = substr($lastTransId, 0, 19);
+        }
 
         Magento2CoreSetup::bootstrap();
         $orderService= new \Pagarme\Core\Payment\Services\OrderService();

--- a/Block/Payment/Pix.php
+++ b/Block/Payment/Pix.php
@@ -80,7 +80,10 @@ class Pix extends Template
         }
 
         $lastTransId = $info->getLastTransId();
-        $orderId = substr($lastTransId, 0, 19);
+        $orderId = null;
+        if ($lastTransId) {
+            $orderId = substr($lastTransId, 0, 19);
+        }
 
         Magento2CoreSetup::bootstrap();
         $orderService= new \Pagarme\Core\Payment\Services\OrderService();

--- a/Concrete/Magento2CoreSetup.php
+++ b/Concrete/Magento2CoreSetup.php
@@ -426,10 +426,10 @@ final class Magento2CoreSetup extends AbstractModuleCoreSetup
 
         $scope = ScopeInterface::SCOPE_WEBSITES;
         $storeId = self::getCurrentStoreId();
-
+        $selectedBrands = $storeConfig->getValue($section .  'cctypes', $scope, $storeId) ?? "";
         $brands = array_merge([''], explode(
             ',',
-            $storeConfig->getValue($section .  'cctypes', $scope, $storeId)
+            $selectedBrands
         ));
 
         $cardConfigs = [];

--- a/Concrete/Magento2PlatformInvoiceDecorator.php
+++ b/Concrete/Magento2PlatformInvoiceDecorator.php
@@ -162,7 +162,7 @@ class Magento2PlatformInvoiceDecorator extends AbstractInvoiceDecorator implemen
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->platformInvoice->getData();
     }

--- a/Concrete/Magento2PlatformInvoiceDecorator.php
+++ b/Concrete/Magento2PlatformInvoiceDecorator.php
@@ -162,7 +162,8 @@ class Magento2PlatformInvoiceDecorator extends AbstractInvoiceDecorator implemen
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->platformInvoice->getData();
     }

--- a/Concrete/Magento2PlatformOrderDecorator.php
+++ b/Concrete/Magento2PlatformOrderDecorator.php
@@ -530,26 +530,24 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
             $quote->getCustomerLastname(),
         ]);
 
-        $fullName = preg_replace("/  /", " ", $fullName);
+        if ($fullName && !is_null($fullName)) {
+            $fullName = preg_replace("/  /", " ", $fullName);
+        }
 
         $customer->setName($fullName);
         $customer->setEmail($quote->getCustomerEmail());
 
-        $cleanDocument = preg_replace(
-            '/\D/',
-            '',
-            $quote->getCustomer()->getTaxVat()
-        );
+        $customerDocument = $quote->getCustomer()->getTaxVat();
 
-        if (empty($cleanDocument)) {
-            $cleanDocument = preg_replace(
-                '/\D/',
-                '',
-                $address->getVatId()
-            );
+        if (!$customerDocument) {
+            $customerDocument =  $address->getVatId();
         }
 
-        $customer->setDocument($cleanDocument);
+        if (!is_null($customerDocument)) {
+            $customerDocument = $this->cleanCustomerDocument($customerDocument);
+        }
+
+        $customer->setDocument($customerDocument);
         $customer->setType(CustomerType::individual());
 
         $telephone = $address->getTelephone();
@@ -567,6 +565,19 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
     }
 
     /**
+     * @param string $document
+     * @return array|string|string[]|null
+     */
+    public function cleanCustomerDocument(string $document)
+    {
+        return preg_replace(
+            '/\D/',
+            '',
+            $document
+        );
+    }
+
+    /**
      * @param Quote $quote
      * @return Customer
      * @throws \Exception
@@ -580,21 +591,17 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
         $customer->setName($guestAddress->getName());
         $customer->setEmail($guestAddress->getEmail());
 
-        $cleanDocument = preg_replace(
-            '/\D/',
-            '',
-            $guestAddress->getVatId()
-        );
+        $customerDocument = $guestAddress->getVatId();
 
-        if (empty($cleanDocument)) {
-            $cleanDocument = preg_replace(
-                '/\D/',
-                '',
-                $quote->getCustomerTaxvat()
-            );
+        if (!$customerDocument) {
+            $customerDocument = $quote->getCustomerTaxvat();
         }
 
-        $customer->setDocument($cleanDocument);
+        if (!is_null($customerDocument)) {
+            $customerDocument = $this->cleanCustomerDocument($customerDocument);
+        }
+
+        $customer->setDocument($customerDocument);
         $customer->setType(CustomerType::individual());
 
         $telephone = $guestAddress->getTelephone();
@@ -967,7 +974,7 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
         foreach ($fields as $key => $attribute) {
             $value = $additionalInformation[$key];
 
-            if ($attribute === 'document' || $attribute === 'zipCode') {
+            if (($attribute === 'document' || $attribute === 'zipCode') && !is_null($value)) {
                 $value = preg_replace(
                     '/\D/',
                     '',

--- a/Gateway/Transaction/Base/Config/Config.php
+++ b/Gateway/Transaction/Base/Config/Config.php
@@ -63,8 +63,8 @@ class Config extends AbstractConfig implements ConfigInterface
     public function isSandboxMode(): bool
     {
         return ( $this->getHubEnvironment() === static::HUB_SANDBOX_ENVIRONMENT ||
-            strpos($this->getSecretKey(), 'sk_test') !== false ||
-            strpos($this->getPublicKey(), 'pk_test') !== false
+            strpos($this->getSecretKey() ?? '', 'sk_test') !== false ||
+            strpos($this->getPublicKey() ?? '', 'pk_test') !== false
         );
     }
 

--- a/Helper/CustomerUpdatePagarmeHelper.php
+++ b/Helper/CustomerUpdatePagarmeHelper.php
@@ -9,8 +9,7 @@
 namespace Pagarme\Pagarme\Helper;
 
 use Magento\Customer\Api\CustomerRepositoryInterface;
-use PagarmeCoreApiLib\Controllers;
-use PagarmeCoreApiLib\Models\UpdateCustomerRequest;
+use Pagarme\Core\Payment\Services\CustomerService;
 use Pagarme\Pagarme\Gateway\Transaction\Base\Config\Config;
 
 class CustomerUpdatePagarmeHelper
@@ -26,13 +25,13 @@ class CustomerUpdatePagarmeHelper
      * AdminCustomerSaveAfter constructor.
      */
     public function __construct(
-        UpdateCustomerRequest $updateCustomerRequest,
         Config $config,
-        CustomerRepositoryInterface $customerRepositoryInterface
+        CustomerRepositoryInterface $customerRepositoryInterface,
+        CustomerService $customerService
     ) {
-        $this->updateCustomerRequest = $updateCustomerRequest;
         $this->config = $config;
         $this->customerRepositoryInterface = $customerRepositoryInterface;
+        $this->customerService = $customerService;
     }
 
 
@@ -42,45 +41,10 @@ class CustomerUpdatePagarmeHelper
      */
     public function updateEmailPagarme($customer)
     {
-
         $oldCustomer = $this->customerRepositoryInterface->getById($customer->getId());
-
         if($oldCustomer->getCustomAttribute('customer_id_pagarme') && ($oldCustomer->getEmail() != $customer->getEmail())){
-
-            $customerIdPagarme = $oldCustomer->getCustomAttribute('customer_id_pagarme')->getValue();
-
-            $this->updateCustomerRequest->email = $customer->getEmail();
-            $this->updateCustomerRequest->name = $oldCustomer->getFirstName() . ' ' . $oldCustomer->getLastName();
-            $customerDocument = $oldCustomer->getTaxvat();
-
-            if (is_null($customerDocument)) {
-                $customerDocument = '';
-            }
-
-            $this->updateCustomerRequest->document = preg_replace('/[\/.-]/', '', $customerDocument);
-            $this->updateCustomerRequest->type = 'individual';
-
-            $this->getApi()->getCustomers()->updateCustomer($customerIdPagarme, $this->updateCustomerRequest);
-
+            $this->customerService->updateCustomerAtPagarme($customer);
         }
-
-    }
-
-    /**
-     * Singleton access to Customers controller
-     * @return Controllers\CustomersController The *Singleton* instance
-     */
-    public function getCustomers()
-    {
-        return Controllers\CustomersController::getInstance();
-    }
-
-    /**
-     * @return \PagarmeCoreApiLib\PagarmeCoreApiClient
-     */
-    public function getApi()
-    {
-        return new \PagarmeCoreApiLib\PagarmeCoreApiClient($this->config->getSecretKey(), '');
     }
 
 }

--- a/Helper/CustomerUpdatePagarmeHelper.php
+++ b/Helper/CustomerUpdatePagarmeHelper.php
@@ -51,7 +51,13 @@ class CustomerUpdatePagarmeHelper
 
             $this->updateCustomerRequest->email = $customer->getEmail();
             $this->updateCustomerRequest->name = $oldCustomer->getFirstName() . ' ' . $oldCustomer->getLastName();
-            $this->updateCustomerRequest->document = preg_replace('/[\/.-]/', '', $oldCustomer->getTaxvat());
+            $customerDocument = $oldCustomer->getTaxvat();
+
+            if (is_null($customerDocument)) {
+                $customerDocument = '';
+            }
+
+            $this->updateCustomerRequest->document = preg_replace('/[\/.-]/', '', $customerDocument);
             $this->updateCustomerRequest->type = 'individual';
 
             $this->getApi()->getCustomers()->updateCustomer($customerIdPagarme, $this->updateCustomerRequest);

--- a/Model/PagarmeConfigProvider.php
+++ b/Model/PagarmeConfigProvider.php
@@ -96,7 +96,7 @@ class PagarmeConfigProvider implements ConfigProviderInterface
     public function validateSoftDescription()
     {
         $isGatewayIntegrationType = $this->isGatewayIntegrationType();
-        $softDescription = $this->getSoftDescription();
+        $softDescription = $this->getSoftDescription() ?? "";
         $maxSizeForGateway = 22;
         $maxSizeForPSP = 13;
 

--- a/Observer/CreditCardDataAssignObserver.php
+++ b/Observer/CreditCardDataAssignObserver.php
@@ -74,7 +74,9 @@ class CreditCardDataAssignObserver extends AbstractDataAssignObserver
         }else{
             $info->setAdditionalInformation('cc_saved_card', $additionalData->getCcSavedCard());
             $info->setAdditionalInformation('cc_type', $additionalData->getCcType());
-            $info->setAdditionalInformation('cc_last_4', substr($additionalData->getCcLast4(),-4));
+            if ($additionalData->getCcLast4()) {
+                $info->setAdditionalInformation('cc_last_4', substr($additionalData->getCcLast4(),-4));
+            }
             $info->setAdditionalInformation('cc_token_credit_card', $additionalData->getCcTokenCreditCard());
             $info->addData([
                 'cc_type' => $additionalData->getCcType(),

--- a/Observer/CreditCardOrderPlaceBeforeObserver.php
+++ b/Observer/CreditCardOrderPlaceBeforeObserver.php
@@ -51,13 +51,17 @@ class CreditCardOrderPlaceBeforeObserver implements ObserverInterface
         if($payment->getMethod() == 'pagarme_creditcard'){
             $tax = $this->getTaxOrder(
                 $payment->getAdditionalInformation('cc_installments'),
-                $payment->getAdditionalInformation('cc_type'),
-                $order
+                $order,
+                $payment->getAdditionalInformation('cc_type')
             );
         }
 
         if($payment->getMethod() == 'pagarme_billet_creditcard'){
-            $tax = $this->getTaxOrderByAmount($payment->getAdditionalInformation('cc_installments'), $payment->getCcType(), $payment->getAdditionalInformation('cc_cc_amount'));
+            $tax = $this->getTaxOrderByAmount(
+                $payment->getAdditionalInformation('cc_installments'),
+                $payment->getAdditionalInformation('cc_cc_amount'),
+                $payment->getCcType()
+            );
         }
 
         if($payment->getMethod() == 'pagarme_two_creditcard'){
@@ -71,7 +75,7 @@ class CreditCardOrderPlaceBeforeObserver implements ObserverInterface
         return $this;
     }
 
-    protected function getTaxOrder($installments, $type = null, $order)
+    protected function getTaxOrder($installments, $order, $type = null)
     {
         $installmentService = new InstallmentService();
 
@@ -98,7 +102,7 @@ class CreditCardOrderPlaceBeforeObserver implements ObserverInterface
         return $result;
     }
 
-    protected function getTaxOrderByAmount($installments, $type = null, $amount)
+    protected function getTaxOrderByAmount($installments, $amount, $type = null)
     {
         $returnInstallments = $this->getInstallmentsByBrandAndAmountInterface()->getInstallmentsByBrandAndAmount($type,$amount);
         $result = 0;

--- a/Observer/CustomerAddressSaveBefore.php
+++ b/Observer/CustomerAddressSaveBefore.php
@@ -62,7 +62,7 @@ class CustomerAddressSaveBefore implements ObserverInterface
             throw new InputException(__("Please check your address. Country is required."));
         }
 
-        if (empty($customerAddress->getName()) || $customerAddress->getName() > 65) {
+        if (empty($customerAddress->getName()) || strlen($customerAddress->getName()) > 65) {
             throw new InputException(__("Please check your address. Name and firstname are required."));
         }
 

--- a/Observer/DebitDataAssignObserver.php
+++ b/Observer/DebitDataAssignObserver.php
@@ -61,7 +61,9 @@ class DebitDataAssignObserver extends AbstractDataAssignObserver
     {
         $info->setAdditionalInformation('cc_saved_card', $additionalData->getCcSavedCard());
         $info->setAdditionalInformation('cc_type', $additionalData->getCcType());
-        $info->setAdditionalInformation('cc_last_4', substr($additionalData->getCcLast4(),-4));
+        if ($additionalData->getCcLast4()) {
+            $info->setAdditionalInformation('cc_last_4', substr($additionalData->getCcLast4(),-4));
+        }
         $info->setAdditionalInformation('cc_token_credit_card', $additionalData->getCcTokenCreditCard());
         $info->addData([
             'cc_type' => $additionalData->getCcType(),

--- a/Observer/VoucherDataAssignObserver.php
+++ b/Observer/VoucherDataAssignObserver.php
@@ -61,7 +61,7 @@ class VoucherDataAssignObserver extends AbstractDataAssignObserver
     {
         $info->setAdditionalInformation('cc_saved_card', $additionalData->getCcSavedCard());
         $info->setAdditionalInformation('cc_type', $additionalData->getCcType());
-        $info->setAdditionalInformation('cc_last_4', substr($additionalData->getCcLast4(),-4));
+        $info->setAdditionalInformation('cc_last_4', substr($additionalData->getCcLast4() ?? '',-4));
         $info->setAdditionalInformation('cc_token_credit_card', $additionalData->getCcTokenCreditCard());
         $info->addData([
             'cc_type' => $additionalData->getCcType(),

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
     "name": "pagarme/pagarme-magento2-module",
     "license": "MIT",
-    "version": "2.0.2",
+    "version": "2.1.0",
     "type": "magento2-module",
     "description": "Magento 2 Module Pagar.me",
     "require": {
-        "php": "~7.1",
-        "pagarme/pagarmecoreapi": "^5.7",
+        "php": ">= 7.1",
+        "pagarme/pagarmecoreapi": "~5.7.0",
         "pagarme/ecommerce-module-core": "dev-develop"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "pagarme/pagarme-magento2-module",
     "license": "MIT",
-    "version": "1.2.0",
+    "version": "2.0.2",
     "type": "magento2-module",
     "description": "Magento 2 Module Pagar.me",
     "require": {

--- a/view/frontend/web/js/core/checkout/PaymentMethodController.js
+++ b/view/frontend/web/js/core/checkout/PaymentMethodController.js
@@ -473,7 +473,7 @@ PaymentMethodController.prototype.addCreditCardInstallmentsListener = function (
 PaymentMethodController.prototype.addSavedCreditCardsListener = function(formObject) {
 
     var paymentMethodController = this;
-    var selector = formObject.savedCreditCardSelect.selector;
+    var selector = formObject.savedCreditCardSelect;
     var brand = jQuery(selector + ' option:selected').attr('brand');
 
     if (brand == undefined) {
@@ -755,9 +755,9 @@ PaymentMethodController.prototype.fillSavedCreditCardsSelect = function (formObj
     formHandler.init(formObject);
     formHandler.fillSavedCreditCardsSelect(platformConfig, formObject);
 
-    if (typeof formObject.savedCreditCardSelect.selector != 'undefined') {
+    if (typeof formObject.savedCreditCardSelect != 'undefined') {
 
-        selector = formObject.savedCreditCardSelect.selector;
+        selector = formObject.savedCreditCardSelect;
         var brand = jQuery(selector + ' option:selected').attr('brand');
 
         if (brand == undefined) {
@@ -791,7 +791,7 @@ PaymentMethodController.prototype.removeMultibuyerForm = function (formObject) {
 };
 
 PaymentMethodController.prototype.addShowMultibuyerListener = function(formObject) {
-    jQuery(formObject.multibuyer.showMultibuyer.selector).on('click', function () {
+    jQuery(formObject.multibuyer.showMultibuyer).on('click', function () {
         formHandler.init(formObject);
         formHandler.toggleMultibuyer(formObject);
     });

--- a/view/frontend/web/js/core/checkout/PaymentMethodController.js
+++ b/view/frontend/web/js/core/checkout/PaymentMethodController.js
@@ -395,7 +395,7 @@ PaymentMethodController.prototype.addCreditCardNumberListener = function(formObj
         setTimeout(function() {
             paymentMethodController.setBin(binObj,  element, formObject);
         }, 300);
-    }).bind(this);
+    });
 };
 
 PaymentMethodController.prototype.twoCardsTotal = function (paymentMethod) {

--- a/view/frontend/web/js/core/checkout/PaymentMethodController.js
+++ b/view/frontend/web/js/core/checkout/PaymentMethodController.js
@@ -399,8 +399,8 @@ PaymentMethodController.prototype.addCreditCardNumberListener = function(formObj
 };
 
 PaymentMethodController.prototype.twoCardsTotal = function (paymentMethod) {
-    var card1 = paymentMethod.formObject[0].creditCardInstallments.selector;
-    var card2 = paymentMethod.formObject[1].creditCardInstallments.selector;
+    var card1 = paymentMethod.formObject[0].creditCardInstallments;
+    var card2 = paymentMethod.formObject[1].creditCardInstallments;
 
     var totalCard1 = paymentMethod.formObject[0].inputAmount.val().replace(platformConfig.currency.decimalSeparator, ".");
     var totalCard2 = paymentMethod.formObject[1].inputAmount.val().replace(platformConfig.currency.decimalSeparator, ".");
@@ -418,7 +418,7 @@ PaymentMethodController.prototype.twoCardsTotal = function (paymentMethod) {
 }
 
 PaymentMethodController.prototype.boletoCreditCardTotal = function (paymentMethod) {
-    var cardElement = paymentMethod.formObject[1].creditCardInstallments.selector;
+    var cardElement = paymentMethod.formObject[1].creditCardInstallments;
 
     var sumInterestTotal = jQuery(cardElement).find(":selected").attr("interest");
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-288
| **What?**         | Adjusting compatibility between php 7 and php 8
| **Why?**          | To unify php7 and php8 deployments and avoid rework
| **How?**          | Adding the #[\ReturnTypeWillChange] attribute and delegating the client update function to the ecommerce module core

About [#[\ReturnTypeWillChange]](https://www.php.net/manual/en/class.returntypewillchange.php)
