### PR TITLE
PAOPN-295 PIX QRCode image was blocked by CSP

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -6,11 +6,13 @@
         <policy id="connect-src">
             <values>
                 <value id="mundipagg-api" type="host">https://api.mundipagg.com</value>
+                <value id="pagarme-api" type="host">https://api.pagar.me</value>
             </values>
         </policy>
         <policy id="img-src">
             <values>
                 <value id="mundipagg-img" type="host">https://cdn.mundipagg.com</value>
+                <value id="pagarme-img" type="host">https://api.pagar.me</value>
             </values>
         </policy>
     </policies>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**           | [https://mundipagg.atlassian.net/browse/PAOPN-295](https://mundipagg.atlassian.net/browse/PAOPN-295)
| **What?**         | Fixed PIX QRCode not showing on the store.
| **Why?**          | PIX QRCode was being blocked by CSP policy.
| **How?**          | Added _https://api.pagar.me_ to CSP Whitelist.