### PR TITLE
Bugfix/paopn 292/error visualizing order in admin

### DIFF
--- a/Block/Payment/Info/Billet.php
+++ b/Block/Payment/Info/Billet.php
@@ -145,6 +145,10 @@ class Billet extends Info
          * @var \Pagarme\Core\Kernel\Aggregates\Order orderObject
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
-        return $orderObject->getCharges()[0]->getLastTransaction();
+        if (is_object($orderObject->getCharges())) {
+            return $orderObject->getCharges()[0]->getLastTransaction();
+        } else {
+            return [];
+        }
     }
 }

--- a/Block/Payment/Info/Billet.php
+++ b/Block/Payment/Info/Billet.php
@@ -78,6 +78,7 @@ class Billet extends Info
 
         $orderRepository = new OrderRepository();
         $order = $orderRepository->findByPagarmeId(new OrderId($orderId));
+        $boletoUrl = null;
 
         if ($order !== null) {
             $charges = $order->getCharges();
@@ -145,10 +146,11 @@ class Billet extends Info
          * @var \Pagarme\Core\Kernel\Aggregates\Order orderObject
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
-        if (is_object($orderObject->getCharges())) {
-            return $orderObject->getCharges()[0]->getLastTransaction();
-        } else {
+
+        if ($orderObject === null) {
             return [];
         }
+        
+        return $orderObject->getCharges()[0]->getLastTransaction();
     }
 }

--- a/Block/Payment/Info/BilletCreditCard.php
+++ b/Block/Payment/Info/BilletCreditCard.php
@@ -139,6 +139,7 @@ class BilletCreditCard extends Cc
 
         $orderRepository = new OrderRepository();
         $order = $orderRepository->findByPagarmeId(new OrderId($orderId));
+        $boletoUrl = null;
 
         if ($order !== null) {
             $charges = $order->getCharges();
@@ -196,23 +197,25 @@ class BilletCreditCard extends Cc
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
         $transactionList = [];
 
-        if (is_object($orderObject->getCharges())) {
-            $lastTransaction = $orderObject->getCharges()[0]->getLastTransaction();
-            $secondLastTransaction = $orderObject->getCharges()[1]->getLastTransaction();
+        if ($orderObject === null) {
+            return [];
+        }
 
-            foreach ([$lastTransaction, $secondLastTransaction] as $item) {
-                if ($item->getAcquirerNsu() != 0) {
-                    $transactionList['creditCard'] =
-                        array_merge(
-                            $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
-                            ['tid' => $this->getTid($orderObject->getCharges()[0])]
-                        );
+        $lastTransaction = $orderObject->getCharges()[0]->getLastTransaction();
+        $secondLastTransaction = $orderObject->getCharges()[1]->getLastTransaction();
 
-                    continue;
-                }
+        foreach ([$lastTransaction, $secondLastTransaction] as $item) {
+            if ($item->getAcquirerNsu() != 0) {
+                $transactionList['creditCard'] =
+                    array_merge(
+                        $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
+                        ['tid' => $this->getTid($orderObject->getCharges()[0])]
+                    );
 
-                $transactionList['billet'] = $item;
+                continue;
             }
+
+            $transactionList['billet'] = $item;
         }
 
         return $transactionList;

--- a/Block/Payment/Info/BilletCreditCard.php
+++ b/Block/Payment/Info/BilletCreditCard.php
@@ -194,23 +194,25 @@ class BilletCreditCard extends Cc
          * @var \Pagarme\Core\Kernel\Aggregates\Order orderObject
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
-
-        $lastTransaction = $orderObject->getCharges()[0]->getLastTransaction();
-        $secondLastTransaction = $orderObject->getCharges()[1]->getLastTransaction();
-
         $transactionList = [];
-        foreach ([$lastTransaction, $secondLastTransaction] as $item) {
-            if ($item->getAcquirerNsu() != 0) {
-                $transactionList['creditCard'] =
-                    array_merge(
-                        $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
-                        ['tid' => $this->getTid($orderObject->getCharges()[0])]
-                    );
 
-                continue;
+        if (is_object($orderObject->getCharges())) {
+            $lastTransaction = $orderObject->getCharges()[0]->getLastTransaction();
+            $secondLastTransaction = $orderObject->getCharges()[1]->getLastTransaction();
+
+            foreach ([$lastTransaction, $secondLastTransaction] as $item) {
+                if ($item->getAcquirerNsu() != 0) {
+                    $transactionList['creditCard'] =
+                        array_merge(
+                            $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
+                            ['tid' => $this->getTid($orderObject->getCharges()[0])]
+                        );
+
+                    continue;
+                }
+
+                $transactionList['billet'] = $item;
             }
-
-            $transactionList['billet'] = $item;
         }
 
         return $transactionList;

--- a/Block/Payment/Info/CreditCard.php
+++ b/Block/Payment/Info/CreditCard.php
@@ -87,14 +87,14 @@ class CreditCard extends Cc
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
 
-        if (is_object($orderObject->getCharges())) {
-            return array_merge(
-                $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
-                ['tid' => $this->getTid($orderObject->getCharges()[0])]
-            );
-        } else {
+        if ($orderObject === null) {
             return [];
         }
+        
+        return array_merge(
+            $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
+            ['tid' => $this->getTid($orderObject->getCharges()[0])]
+        );
     }
 
     private function getTid(Charge $charge)

--- a/Block/Payment/Info/CreditCard.php
+++ b/Block/Payment/Info/CreditCard.php
@@ -87,10 +87,14 @@ class CreditCard extends Cc
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
 
-        return array_merge(
-            $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
-            ['tid' => $this->getTid($orderObject->getCharges()[0])]
-        );
+        if (is_object($orderObject->getCharges())) {
+            return array_merge(
+                $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
+                ['tid' => $this->getTid($orderObject->getCharges()[0])]
+            );
+        } else {
+            return [];
+        }
     }
 
     private function getTid(Charge $charge)

--- a/Block/Payment/Info/Pix.php
+++ b/Block/Payment/Info/Pix.php
@@ -71,6 +71,11 @@ class Pix extends Info
          * @var Order orderObject
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
-        return $orderObject->getCharges()[0]->getLastTransaction();
+
+        if (is_object($orderObject->getCharges())) {
+            return $orderObject->getCharges()[0]->getLastTransaction();
+        } else {
+            return [];
+        }
     }
 }

--- a/Block/Payment/Info/Pix.php
+++ b/Block/Payment/Info/Pix.php
@@ -72,10 +72,10 @@ class Pix extends Info
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
 
-        if (is_object($orderObject->getCharges())) {
-            return $orderObject->getCharges()[0]->getLastTransaction();
-        } else {
+        if ($orderObject === null) {
             return [];
         }
+
+        return $orderObject->getCharges()[0]->getLastTransaction();
     }
 }

--- a/Block/Payment/Info/TwoCreditCard.php
+++ b/Block/Payment/Info/TwoCreditCard.php
@@ -116,17 +116,21 @@ class TwoCreditCard extends Cc
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
 
-        return [
-            'card1' => array_merge(
-                $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
-                ['tid' => $this->getTid($orderObject->getCharges()[0])]
-            ),
+        if (is_object($orderObject->getCharges())) {
+            return [
+                'card1' => array_merge(
+                    $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
+                    ['tid' => $this->getTid($orderObject->getCharges()[0])]
+                ),
 
-            'card2' => array_merge(
-                $orderObject->getCharges()[1]->getAcquirerTidCapturedAndAutorize(),
-                ['tid' => $this->getTid($orderObject->getCharges()[1])]
-            )
-        ];
+                'card2' => array_merge(
+                    $orderObject->getCharges()[1]->getAcquirerTidCapturedAndAutorize(),
+                    ['tid' => $this->getTid($orderObject->getCharges()[1])]
+                )
+            ];
+        } else {
+            return [];
+        }
     }
 
     private function getTid(Charge $charge)

--- a/Block/Payment/Info/TwoCreditCard.php
+++ b/Block/Payment/Info/TwoCreditCard.php
@@ -116,21 +116,21 @@ class TwoCreditCard extends Cc
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
 
-        if (is_object($orderObject->getCharges())) {
-            return [
-                'card1' => array_merge(
-                    $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
-                    ['tid' => $this->getTid($orderObject->getCharges()[0])]
-                ),
-
-                'card2' => array_merge(
-                    $orderObject->getCharges()[1]->getAcquirerTidCapturedAndAutorize(),
-                    ['tid' => $this->getTid($orderObject->getCharges()[1])]
-                )
-            ];
-        } else {
+        if ($orderObject === null) {
             return [];
         }
+
+        return [
+            'card1' => array_merge(
+                $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
+                ['tid' => $this->getTid($orderObject->getCharges()[0])]
+            ),
+
+            'card2' => array_merge(
+                $orderObject->getCharges()[1]->getAcquirerTidCapturedAndAutorize(),
+                ['tid' => $this->getTid($orderObject->getCharges()[1])]
+            )
+        ];
     }
 
     private function getTid(Charge $charge)

--- a/view/adminhtml/templates/info/billetCreditCard.phtml
+++ b/view/adminhtml/templates/info/billetCreditCard.phtml
@@ -4,7 +4,10 @@
  * @var \Pagarme\Core\Kernel\Aggregates\Transaction $lastTransaction
  */
 $lastTransactions = $this->getTransactionInfo();
-$postDataBillet = (json_decode($lastTransactions['billet']->getPostData()->tran_data, true));
+$postDataBillet = null;
+if (array_key_exists('billet', $lastTransactions)) {
+    $postDataBillet = (json_decode($lastTransactions['billet']->getPostData()->tran_data, true));
+}
 ?>
 <?php if ($this->getCcType()): ?>
     <span><?php echo __($this->getTitle()); ?></span>
@@ -32,7 +35,9 @@ $postDataBillet = (json_decode($lastTransactions['billet']->getPostData()->tran_
         <span><b><?= __('NSU from capture'); ?>: </b><?= $lastTransactions['creditCard']['captured'] ?></span>
         <br/>
     <?php } ?>
-    <span><b><?= __('TID'); ?>: </b><?= $lastTransactions['creditCard']['tid'] ?></span>
+    <?php if (!empty($lastTransactions['creditCard']['tid'])) {?>
+        <span><b><?= __('TID'); ?>: </b><?= $lastTransactions['creditCard']['tid'] ?></span>
+    <?php } ?>
 <?php endif ?>
 
     <br/>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**           | [https://mundipagg.atlassian.net/browse/PAOPN-292](https://mundipagg.atlassian.net/browse/PAOPN-292)
| **What?**         | Checked if charge and transaction existis before using them
| **Why?**          | Admin Order View had error if these informations were removed from the database
| **How?**          | Returning empty array if $orderObject is null