### PR TITLE
PAOPN-288: adjusting compatibility between php 7 and php 8

### DIFF
--- a/Block/Payment/Billet.php
+++ b/Block/Payment/Billet.php
@@ -16,13 +16,7 @@ use Magento\Framework\View\Element\Template\Context;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Sales\Api\Data\OrderInterface as Order;
 use Magento\Sales\Api\Data\OrderPaymentInterface as Payment;
-use Pagarme\Core\Kernel\Repositories\OrderRepository;
-use Pagarme\Core\Kernel\ValueObjects\Id\OrderId;
-use Pagarme\Core\Kernel\ValueObjects\Id\SubscriptionId;
-use Pagarme\Core\Recurrence\Repositories\SubscriptionRepository;
-use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
-use Pagarme\Core\Recurrence\Repositories\ChargeRepository as SubscriptionChargeRepository;
-
+use Pagarme\Pagarme\Helper\Payment\Billet as BilletHelper;
 class Billet extends Template
 {
     protected $checkoutSession;
@@ -31,8 +25,7 @@ class Billet extends Template
      * @param Context $context
      * @param CheckoutSession $checkoutSession
      */
-    public function __construct(Context $context, CheckoutSession $checkoutSession)
-    {
+    public function __construct(Context $context, CheckoutSession $checkoutSession){
         $this->checkoutSession = $checkoutSession;
         parent::__construct($context, []);
     }
@@ -72,75 +65,7 @@ class Billet extends Template
      */
     public function getBilletUrl()
     {
-        $method = $this->getPayment()->getMethod();
-
-        if (strpos($method, "pagarme_billet") === false) {
-            return;
-        }
-        $info = $this->getPayment();
-
-        $boletoUrl = $this->getPayment()->getAdditionalInformation('billet_url');
-
-        Magento2CoreSetup::bootstrap();
-        $boletoUrl = $this->getBoletoLinkFromOrder($info);
-
-        if (!$boletoUrl) {
-            $boletoUrl = $this->getBoletoLinkFromSubscription($info);
-        }
-
-        return $boletoUrl;
-    }
-
-    private function getBoletoLinkFromOrder($info)
-    {
-        $lastTransId = $info->getLastTransId();
-        $orderId = null;
-        if ($lastTransId) {
-            $orderId = substr($lastTransId, 0, 19);
-        }
-
-        if (!$orderId) {
-            return null;
-        }
-
-        $orderRepository = new OrderRepository();
-        $order = $orderRepository->findByPagarmeId(new OrderId($orderId));
-
-        if ($order !== null) {
-            $charges = $order->getCharges();
-            foreach ($charges as $charge) {
-                $transaction = $charge->getLastTransaction();
-                $savedBoletoUrl = $transaction->getBoletoUrl();
-                if ($savedBoletoUrl !== null) {
-                    $boletoUrl = $savedBoletoUrl;
-                }
-            }
-        }
-
-        return $boletoUrl;
-    }
-
-    private function getBoletoLinkFromSubscription($info)
-    {
-        $subscriptionRepository = new SubscriptionRepository();
-        $subscription = $subscriptionRepository->findByCode($info->getOrder()->getIncrementId());
-
-        if (!$subscription) {
-            return null;
-        }
-
-        $chargeRepository = new SubscriptionChargeRepository();
-        $subscriptionId =
-            new SubscriptionId(
-                $subscription->getPagarmeId()->getValue()
-            );
-
-        $charge = $chargeRepository->findBySubscriptionId($subscriptionId);
-
-        if (!empty($charge[0])) {
-            return $charge[0]->getBoletoUrl();
-        }
-
-        return null;
+        $billetHelper = new BilletHelper();
+        return $billetHelper->getBilletUrl($this->getPayment());
     }
 }

--- a/Block/Payment/Billet.php
+++ b/Block/Payment/Billet.php
@@ -25,7 +25,8 @@ class Billet extends Template
      * @param Context $context
      * @param CheckoutSession $checkoutSession
      */
-    public function __construct(Context $context, CheckoutSession $checkoutSession){
+    public function __construct(Context $context, CheckoutSession $checkoutSession)
+    {
         $this->checkoutSession = $checkoutSession;
         parent::__construct($context, []);
     }

--- a/Block/Payment/Billet.php
+++ b/Block/Payment/Billet.php
@@ -94,7 +94,10 @@ class Billet extends Template
     private function getBoletoLinkFromOrder($info)
     {
         $lastTransId = $info->getLastTransId();
-        $orderId = substr($lastTransId, 0, 19);
+        $orderId = null;
+        if ($lastTransId) {
+            $orderId = substr($lastTransId, 0, 19);
+        }
 
         if (!$orderId) {
             return null;

--- a/Block/Payment/Info/Billet.php
+++ b/Block/Payment/Info/Billet.php
@@ -149,11 +149,10 @@ class Billet extends Info
          * @var \Pagarme\Core\Kernel\Aggregates\Order orderObject
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
-
-        if ($orderObject === null) {
+        if (is_object($orderObject->getCharges())) {
+            return $orderObject->getCharges()[0]->getLastTransaction();
+        } else {
             return [];
         }
-        
-        return $orderObject->getCharges()[0]->getLastTransaction();
     }
 }

--- a/Block/Payment/Info/Billet.php
+++ b/Block/Payment/Info/Billet.php
@@ -70,7 +70,10 @@ class Billet extends Info
     private function getBoletoLinkFromOrder($info)
     {
         $lastTransId = $info->getLastTransId();
-        $orderId = substr($lastTransId, 0, 19);
+        $orderId = null;
+        if ($lastTransId) {
+            $orderId = substr($lastTransId, 0, 19);
+        }
 
         if (!$orderId) {
             return null;

--- a/Block/Payment/Info/Billet.php
+++ b/Block/Payment/Info/Billet.php
@@ -149,10 +149,11 @@ class Billet extends Info
          * @var \Pagarme\Core\Kernel\Aggregates\Order orderObject
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
-        if (is_object($orderObject->getCharges())) {
-            return $orderObject->getCharges()[0]->getLastTransaction();
-        } else {
+
+        if ($orderObject === null) {
             return [];
         }
+        
+        return $orderObject->getCharges()[0]->getLastTransaction();
     }
 }

--- a/Block/Payment/Info/Billet.php
+++ b/Block/Payment/Info/Billet.php
@@ -14,14 +14,11 @@ namespace Pagarme\Pagarme\Block\Payment\Info;
 
 use Magento\Payment\Block\Info;
 use Magento\Framework\DataObject;
-use Pagarme\Core\Kernel\Repositories\OrderRepository;
 use Pagarme\Core\Kernel\Services\OrderService;
 use Pagarme\Core\Kernel\ValueObjects\Id\OrderId;
-use Pagarme\Core\Kernel\ValueObjects\Id\SubscriptionId;
-use Pagarme\Core\Recurrence\Repositories\ChargeRepository as SubscriptionChargeRepository;
-use Pagarme\Core\Recurrence\Repositories\SubscriptionRepository;
 use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
 use Pagarme\Pagarme\Concrete\Magento2PlatformOrderDecorator;
+use Pagarme\Pagarme\Helper\Payment\Billet as BilletHelper;
 
 class Billet extends Info
 {
@@ -47,76 +44,8 @@ class Billet extends Info
 
     public function getBilletUrl()
     {
-        $method = $this->getInfo()->getMethod();
-
-        if (strpos($method, "pagarme_billet") === false) {
-            return;
-        }
-
-        $boletoUrl =  $this->getInfo()->getAdditionalInformation('billet_url');
-
-        Magento2CoreSetup::bootstrap();
-        $info = $this->getInfo();
-
-        $boletoUrl = $this->getBoletoLinkFromOrder($info);
-
-        if (!$boletoUrl) {
-            $boletoUrl = $this->getBoletoLinkFromSubscription($info);
-        }
-
-        return $boletoUrl;
-    }
-
-    private function getBoletoLinkFromOrder($info)
-    {
-        $lastTransId = $info->getLastTransId();
-        $orderId = null;
-        if ($lastTransId) {
-            $orderId = substr($lastTransId, 0, 19);
-        }
-
-        if (!$orderId) {
-            return null;
-        }
-
-        $orderRepository = new OrderRepository();
-        $order = $orderRepository->findByPagarmeId(new OrderId($orderId));
-        $boletoUrl = null;
-
-        if ($order !== null) {
-            $charges = $order->getCharges();
-            foreach ($charges as $charge) {
-                $transaction = $charge->getLastTransaction();
-                $savedBoletoUrl = $transaction->getBoletoUrl();
-                if ($savedBoletoUrl !== null) {
-                    $boletoUrl = $savedBoletoUrl;
-                }
-            }
-        }
-
-        return $boletoUrl;
-    }
-
-    private function getBoletoLinkFromSubscription($info)
-    {
-        $subscriptionRepository = new SubscriptionRepository();
-        $subscription = $subscriptionRepository->findByCode($info->getOrder()->getIncrementId());
-
-        if (!$subscription) {
-            return null;
-        }
-
-        $chargeRepository = new SubscriptionChargeRepository();
-        $subscriptionId =
-            new SubscriptionId(
-                $subscription->getPagarmeId()->getValue()
-            );
-
-        $charge = $chargeRepository->findBySubscriptionId($subscriptionId);
-
-        if (!empty($charge[0])) {
-            return $charge[0]->getBoletoLink();
-        }
+        $billetHelper = new BilletHelper();
+        return $billetHelper->getBilletUrl($this->getInfo());
     }
 
     public function getTitle()

--- a/Block/Payment/Info/BilletCreditCard.php
+++ b/Block/Payment/Info/BilletCreditCard.php
@@ -94,7 +94,10 @@ class BilletCreditCard extends Cc
         Magento2CoreSetup::bootstrap();
 
         $lastTransId = $info->getLastTransId();
-        $orderId = substr($lastTransId, 0, 19);
+        $orderId = null;
+        if ($lastTransId) {
+            $orderId = substr($lastTransId, 0, 19);
+        }
 
         $orderRepository = new OrderRepository();
         $order = $orderRepository->findByPagarmeId(new OrderId($orderId));
@@ -131,7 +134,10 @@ class BilletCreditCard extends Cc
     private function getBoletoLinkFromOrder($info)
     {
         $lastTransId = $info->getLastTransId();
-        $orderId = substr($lastTransId, 0, 19);
+        $orderId = null;
+        if ($lastTransId) {
+            $orderId = substr($lastTransId, 0, 19);
+        }
 
         if (!$orderId) {
             return null;

--- a/Block/Payment/Info/BilletCreditCard.php
+++ b/Block/Payment/Info/BilletCreditCard.php
@@ -203,23 +203,25 @@ class BilletCreditCard extends Cc
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
         $transactionList = [];
 
-        if (is_object($orderObject->getCharges())) {
-            $lastTransaction = $orderObject->getCharges()[0]->getLastTransaction();
-            $secondLastTransaction = $orderObject->getCharges()[1]->getLastTransaction();
+        if ($orderObject === null) {
+            return [];
+        }
 
-            foreach ([$lastTransaction, $secondLastTransaction] as $item) {
-                if ($item->getAcquirerNsu() != 0) {
-                    $transactionList['creditCard'] =
-                        array_merge(
-                            $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
-                            ['tid' => $this->getTid($orderObject->getCharges()[0])]
-                        );
+        $lastTransaction = $orderObject->getCharges()[0]->getLastTransaction();
+        $secondLastTransaction = $orderObject->getCharges()[1]->getLastTransaction();
 
-                    continue;
-                }
+        foreach ([$lastTransaction, $secondLastTransaction] as $item) {
+            if ($item->getAcquirerNsu() != 0) {
+                $transactionList['creditCard'] =
+                    array_merge(
+                        $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
+                        ['tid' => $this->getTid($orderObject->getCharges()[0])]
+                    );
 
-                $transactionList['billet'] = $item;
+                continue;
             }
+
+            $transactionList['billet'] = $item;
         }
 
         return $transactionList;

--- a/Block/Payment/Info/BilletCreditCard.php
+++ b/Block/Payment/Info/BilletCreditCard.php
@@ -201,7 +201,6 @@ class BilletCreditCard extends Cc
          * @var \Pagarme\Core\Kernel\Aggregates\Order orderObject
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
-        $transactionList = [];
 
         if ($orderObject === null) {
             return [];
@@ -210,6 +209,7 @@ class BilletCreditCard extends Cc
         $lastTransaction = $orderObject->getCharges()[0]->getLastTransaction();
         $secondLastTransaction = $orderObject->getCharges()[1]->getLastTransaction();
 
+        $transactionList = [];
         foreach ([$lastTransaction, $secondLastTransaction] as $item) {
             if ($item->getAcquirerNsu() != 0) {
                 $transactionList['creditCard'] =

--- a/Block/Payment/Info/CreditCard.php
+++ b/Block/Payment/Info/CreditCard.php
@@ -87,14 +87,14 @@ class CreditCard extends Cc
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
 
-        if (is_object($orderObject->getCharges())) {
-            return array_merge(
-                $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
-                ['tid' => $this->getTid($orderObject->getCharges()[0])]
-            );
-        } else {
+        if ($orderObject === null) {
             return [];
         }
+        
+        return array_merge(
+            $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
+            ['tid' => $this->getTid($orderObject->getCharges()[0])]
+        );
     }
 
     private function getTid(Charge $charge)

--- a/Block/Payment/Info/CreditCard.php
+++ b/Block/Payment/Info/CreditCard.php
@@ -87,14 +87,14 @@ class CreditCard extends Cc
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
 
-        if ($orderObject === null) {
+        if (is_object($orderObject->getCharges())) {
+            return array_merge(
+                $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
+                ['tid' => $this->getTid($orderObject->getCharges()[0])]
+            );
+        } else {
             return [];
         }
-        
-        return array_merge(
-            $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
-            ['tid' => $this->getTid($orderObject->getCharges()[0])]
-        );
     }
 
     private function getTid(Charge $charge)

--- a/Block/Payment/Info/Pix.php
+++ b/Block/Payment/Info/Pix.php
@@ -75,10 +75,10 @@ class Pix extends Info
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
 
-        if ($orderObject === null) {
+        if (is_object($orderObject->getCharges())) {
+            return $orderObject->getCharges()[0]->getLastTransaction();
+        } else {
             return [];
         }
-
-        return $orderObject->getCharges()[0]->getLastTransaction();
     }
 }

--- a/Block/Payment/Info/Pix.php
+++ b/Block/Payment/Info/Pix.php
@@ -10,6 +10,7 @@ use Pagarme\Core\Kernel\Services\OrderService;
 use Pagarme\Core\Kernel\ValueObjects\Id\OrderId;
 use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
 use Pagarme\Pagarme\Concrete\Magento2PlatformOrderDecorator;
+use Pagarme\Pagarme\Helper\Payment\Pix as PixHelper;
 
 class Pix extends Info
 {
@@ -26,22 +27,8 @@ class Pix extends Info
      */
     public function getPixInfo()
     {
-        $info = $this->getInfo();
-        $method = $info->getMethod();
-
-        if (strpos($method, "pagarme_pix") === false) {
-            return null;
-        }
-
-        $lastTransId = $info->getLastTransId();
-        $orderId = null;
-        if ($lastTransId) {
-            $orderId = substr($lastTransId, 0, 19);
-        }
-
-        Magento2CoreSetup::bootstrap();
-        $orderService= new \Pagarme\Core\Payment\Services\OrderService();
-        return $orderService->getPixQrCodeInfoFromOrder(new OrderId($orderId));
+        $pixHelper = new PixHelper();
+        return $pixHelper->getQrCode($this->getInfo());
     }
 
     public function getTitle()

--- a/Block/Payment/Info/Pix.php
+++ b/Block/Payment/Info/Pix.php
@@ -75,10 +75,10 @@ class Pix extends Info
          */
         $orderObject = $orderService->getOrderByPagarmeId(new OrderId($orderPagarmeId));
 
-        if (is_object($orderObject->getCharges())) {
-            return $orderObject->getCharges()[0]->getLastTransaction();
-        } else {
+        if ($orderObject === null) {
             return [];
         }
+
+        return $orderObject->getCharges()[0]->getLastTransaction();
     }
 }

--- a/Block/Payment/Info/Pix.php
+++ b/Block/Payment/Info/Pix.php
@@ -34,7 +34,10 @@ class Pix extends Info
         }
 
         $lastTransId = $info->getLastTransId();
-        $orderId = substr($lastTransId, 0, 19);
+        $orderId = null;
+        if ($lastTransId) {
+            $orderId = substr($lastTransId, 0, 19);
+        }
 
         Magento2CoreSetup::bootstrap();
         $orderService= new \Pagarme\Core\Payment\Services\OrderService();

--- a/Block/Payment/Info/TwoCreditCard.php
+++ b/Block/Payment/Info/TwoCreditCard.php
@@ -120,17 +120,21 @@ class TwoCreditCard extends Cc
             return [];
         }
 
-        return [
-            'card1' => array_merge(
-                $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
-                ['tid' => $this->getTid($orderObject->getCharges()[0])]
-            ),
+        if (is_object($orderObject->getCharges())) {
+            return [
+                'card1' => array_merge(
+                    $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
+                    ['tid' => $this->getTid($orderObject->getCharges()[0])]
+                ),
 
-            'card2' => array_merge(
-                $orderObject->getCharges()[1]->getAcquirerTidCapturedAndAutorize(),
-                ['tid' => $this->getTid($orderObject->getCharges()[1])]
-            )
-        ];
+                'card2' => array_merge(
+                    $orderObject->getCharges()[1]->getAcquirerTidCapturedAndAutorize(),
+                    ['tid' => $this->getTid($orderObject->getCharges()[1])]
+                )
+            ];
+        } else {
+            return [];
+        }
     }
 
     private function getTid(Charge $charge)

--- a/Block/Payment/Info/TwoCreditCard.php
+++ b/Block/Payment/Info/TwoCreditCard.php
@@ -121,17 +121,18 @@ class TwoCreditCard extends Cc
         }
 
         if (is_object($orderObject->getCharges())) {
-            return [
-                'card1' => array_merge(
-                    $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
-                    ['tid' => $this->getTid($orderObject->getCharges()[0])]
-                ),
+                return [
+                    'card1' => array_merge(
+                        $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
+                        ['tid' => $this->getTid($orderObject->getCharges()[0])]
+                    ),
 
-            'card2' => array_merge(
-                $orderObject->getCharges()[1]->getAcquirerTidCapturedAndAutorize(),
-                ['tid' => $this->getTid($orderObject->getCharges()[1])]
-            )
-        ];
+                'card2' => array_merge(
+                    $orderObject->getCharges()[1]->getAcquirerTidCapturedAndAutorize(),
+                    ['tid' => $this->getTid($orderObject->getCharges()[1])]
+                )
+            ];
+        }
     }
 
     private function getTid(Charge $charge)

--- a/Block/Payment/Info/TwoCreditCard.php
+++ b/Block/Payment/Info/TwoCreditCard.php
@@ -127,14 +127,11 @@ class TwoCreditCard extends Cc
                     ['tid' => $this->getTid($orderObject->getCharges()[0])]
                 ),
 
-                'card2' => array_merge(
-                    $orderObject->getCharges()[1]->getAcquirerTidCapturedAndAutorize(),
-                    ['tid' => $this->getTid($orderObject->getCharges()[1])]
-                )
-            ];
-        } else {
-            return [];
-        }
+            'card2' => array_merge(
+                $orderObject->getCharges()[1]->getAcquirerTidCapturedAndAutorize(),
+                ['tid' => $this->getTid($orderObject->getCharges()[1])]
+            )
+        ];
     }
 
     private function getTid(Charge $charge)

--- a/Block/Payment/Info/TwoCreditCard.php
+++ b/Block/Payment/Info/TwoCreditCard.php
@@ -121,12 +121,11 @@ class TwoCreditCard extends Cc
         }
 
         if (is_object($orderObject->getCharges())) {
-                return [
-                    'card1' => array_merge(
-                        $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
-                        ['tid' => $this->getTid($orderObject->getCharges()[0])]
-                    ),
-
+            return [
+                'card1' => array_merge(
+                    $orderObject->getCharges()[0]->getAcquirerTidCapturedAndAutorize(),
+                    ['tid' => $this->getTid($orderObject->getCharges()[0])]
+                ),
                 'card2' => array_merge(
                     $orderObject->getCharges()[1]->getAcquirerTidCapturedAndAutorize(),
                     ['tid' => $this->getTid($orderObject->getCharges()[1])]

--- a/Block/Payment/Pix.php
+++ b/Block/Payment/Pix.php
@@ -80,7 +80,10 @@ class Pix extends Template
         }
 
         $lastTransId = $info->getLastTransId();
-        $orderId = substr($lastTransId, 0, 19);
+        $orderId = null;
+        if ($lastTransId) {
+            $orderId = substr($lastTransId, 0, 19);
+        }
 
         Magento2CoreSetup::bootstrap();
         $orderService= new \Pagarme\Core\Payment\Services\OrderService();

--- a/Block/Payment/Pix.php
+++ b/Block/Payment/Pix.php
@@ -16,13 +16,7 @@ use Magento\Framework\View\Element\Template\Context;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Sales\Api\Data\OrderInterface as Order;
 use Magento\Sales\Api\Data\OrderPaymentInterface as Payment;
-use Pagarme\Core\Kernel\Repositories\OrderRepository;
-use Pagarme\Core\Kernel\ValueObjects\Id\OrderId;
-use Pagarme\Core\Kernel\ValueObjects\Id\SubscriptionId;
-use Pagarme\Core\Recurrence\Repositories\SubscriptionRepository;
-use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
-use Pagarme\Core\Recurrence\Repositories\ChargeRepository as SubscriptionChargeRepository;
-
+use Pagarme\Pagarme\Helper\Payment\Pix as PixHelper;
 class Pix extends Template
 {
     protected $checkoutSession;
@@ -72,21 +66,7 @@ class Pix extends Template
      */
     public function getPixInfo()
     {
-        $info = $this->getPayment();
-        $method = $info->getMethod();
-
-        if (strpos($method, "pagarme_pix") === false) {
-            return null;
-        }
-
-        $lastTransId = $info->getLastTransId();
-        $orderId = null;
-        if ($lastTransId) {
-            $orderId = substr($lastTransId, 0, 19);
-        }
-
-        Magento2CoreSetup::bootstrap();
-        $orderService= new \Pagarme\Core\Payment\Services\OrderService();
-        return $orderService->getPixQrCodeInfoFromOrder(new OrderId($orderId));
+        $pixHelper = new PixHelper();
+        return $pixHelper->getQrCode($this->getPayment());
     }
 }

--- a/Concrete/Magento2CoreSetup.php
+++ b/Concrete/Magento2CoreSetup.php
@@ -426,10 +426,10 @@ final class Magento2CoreSetup extends AbstractModuleCoreSetup
 
         $scope = ScopeInterface::SCOPE_WEBSITES;
         $storeId = self::getCurrentStoreId();
-
+        $selectedBrands = $storeConfig->getValue($section .  'cctypes', $scope, $storeId) ?? "";
         $brands = array_merge([''], explode(
             ',',
-            $storeConfig->getValue($section .  'cctypes', $scope, $storeId)
+            $selectedBrands
         ));
 
         $cardConfigs = [];

--- a/Concrete/Magento2PlatformInvoiceDecorator.php
+++ b/Concrete/Magento2PlatformInvoiceDecorator.php
@@ -155,14 +155,8 @@ class Magento2PlatformInvoiceDecorator extends AbstractInvoiceDecorator implemen
         return $invoice;
     }
 
-    /**
-     * Specify data which should be serialized to JSON
-     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->platformInvoice->getData();
     }

--- a/Concrete/Magento2PlatformInvoiceDecorator.php
+++ b/Concrete/Magento2PlatformInvoiceDecorator.php
@@ -162,7 +162,7 @@ class Magento2PlatformInvoiceDecorator extends AbstractInvoiceDecorator implemen
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->platformInvoice->getData();
     }

--- a/Concrete/Magento2PlatformOrderDecorator.php
+++ b/Concrete/Magento2PlatformOrderDecorator.php
@@ -537,14 +537,14 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
         $customer->setName($fullName);
         $customer->setEmail($quote->getCustomerEmail());
 
-        $customerDocument = $quote->getCustomer()->getTaxVat();
-
+        $customerDocument = $this->cleanCustomerDocument(
+                                $quote->getCustomer()->getTaxVat()
+                            );
+        
         if (!$customerDocument) {
-            $customerDocument =  $address->getVatId();
-        }
-
-        if (!is_null($customerDocument)) {
-            $customerDocument = $this->cleanCustomerDocument($customerDocument);
+            $customerDocument = $this->cleanCustomerDocument(
+                                    $address->getVatId()
+                                );
         }
 
         $customer->setDocument($customerDocument);
@@ -570,6 +570,9 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
      */
     public function cleanCustomerDocument(string $document)
     {
+        if(is_null($document)) {
+            return '';
+        }
         return preg_replace(
             '/\D/',
             '',

--- a/Concrete/Magento2PlatformOrderDecorator.php
+++ b/Concrete/Magento2PlatformOrderDecorator.php
@@ -530,26 +530,24 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
             $quote->getCustomerLastname(),
         ]);
 
-        $fullName = preg_replace("/  /", " ", $fullName);
+        if ($fullName && !is_null($fullName)) {
+            $fullName = preg_replace("/  /", " ", $fullName);
+        }
 
         $customer->setName($fullName);
         $customer->setEmail($quote->getCustomerEmail());
 
-        $cleanDocument = preg_replace(
-            '/\D/',
-            '',
-            $quote->getCustomer()->getTaxVat()
-        );
+        $customerDocument = $quote->getCustomer()->getTaxVat();
 
-        if (empty($cleanDocument)) {
-            $cleanDocument = preg_replace(
-                '/\D/',
-                '',
-                $address->getVatId()
-            );
+        if (!$customerDocument) {
+            $customerDocument =  $address->getVatId();
         }
 
-        $customer->setDocument($cleanDocument);
+        if (!is_null($customerDocument)) {
+            $customerDocument = $this->cleanCustomerDocument($customerDocument);
+        }
+
+        $customer->setDocument($customerDocument);
         $customer->setType(CustomerType::individual());
 
         $telephone = $address->getTelephone();
@@ -567,6 +565,19 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
     }
 
     /**
+     * @param string $document
+     * @return array|string|string[]|null
+     */
+    public function cleanCustomerDocument(string $document)
+    {
+        return preg_replace(
+            '/\D/',
+            '',
+            $document
+        );
+    }
+
+    /**
      * @param Quote $quote
      * @return Customer
      * @throws \Exception
@@ -580,21 +591,17 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
         $customer->setName($guestAddress->getName());
         $customer->setEmail($guestAddress->getEmail());
 
-        $cleanDocument = preg_replace(
-            '/\D/',
-            '',
-            $guestAddress->getVatId()
-        );
+        $customerDocument = $guestAddress->getVatId();
 
-        if (empty($cleanDocument)) {
-            $cleanDocument = preg_replace(
-                '/\D/',
-                '',
-                $quote->getCustomerTaxvat()
-            );
+        if (!$customerDocument) {
+            $customerDocument = $quote->getCustomerTaxvat();
         }
 
-        $customer->setDocument($cleanDocument);
+        if (!is_null($customerDocument)) {
+            $customerDocument = $this->cleanCustomerDocument($customerDocument);
+        }
+
+        $customer->setDocument($customerDocument);
         $customer->setType(CustomerType::individual());
 
         $telephone = $guestAddress->getTelephone();
@@ -967,7 +974,7 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
         foreach ($fields as $key => $attribute) {
             $value = $additionalInformation[$key];
 
-            if ($attribute === 'document' || $attribute === 'zipCode') {
+            if (($attribute === 'document' || $attribute === 'zipCode') && !is_null($value)) {
                 $value = preg_replace(
                     '/\D/',
                     '',

--- a/Gateway/Transaction/Base/Config/Config.php
+++ b/Gateway/Transaction/Base/Config/Config.php
@@ -63,8 +63,8 @@ class Config extends AbstractConfig implements ConfigInterface
     public function isSandboxMode(): bool
     {
         return ( $this->getHubEnvironment() === static::HUB_SANDBOX_ENVIRONMENT ||
-            strpos($this->getSecretKey(), 'sk_test') !== false ||
-            strpos($this->getPublicKey(), 'pk_test') !== false
+            strpos($this->getSecretKey() ?? '', 'sk_test') !== false ||
+            strpos($this->getPublicKey() ?? '', 'pk_test') !== false
         );
     }
 

--- a/Helper/CustomerUpdatePagarmeHelper.php
+++ b/Helper/CustomerUpdatePagarmeHelper.php
@@ -9,8 +9,7 @@
 namespace Pagarme\Pagarme\Helper;
 
 use Magento\Customer\Api\CustomerRepositoryInterface;
-use PagarmeCoreApiLib\Controllers;
-use PagarmeCoreApiLib\Models\UpdateCustomerRequest;
+use Pagarme\Core\Payment\Services\CustomerService;
 use Pagarme\Pagarme\Gateway\Transaction\Base\Config\Config;
 
 class CustomerUpdatePagarmeHelper
@@ -26,13 +25,13 @@ class CustomerUpdatePagarmeHelper
      * AdminCustomerSaveAfter constructor.
      */
     public function __construct(
-        UpdateCustomerRequest $updateCustomerRequest,
         Config $config,
-        CustomerRepositoryInterface $customerRepositoryInterface
+        CustomerRepositoryInterface $customerRepositoryInterface,
+        CustomerService $customerService
     ) {
-        $this->updateCustomerRequest = $updateCustomerRequest;
         $this->config = $config;
         $this->customerRepositoryInterface = $customerRepositoryInterface;
+        $this->customerService = $customerService;
     }
 
 
@@ -42,39 +41,10 @@ class CustomerUpdatePagarmeHelper
      */
     public function updateEmailPagarme($customer)
     {
-
         $oldCustomer = $this->customerRepositoryInterface->getById($customer->getId());
-
         if($oldCustomer->getCustomAttribute('customer_id_pagarme') && ($oldCustomer->getEmail() != $customer->getEmail())){
-
-            $customerIdPagarme = $oldCustomer->getCustomAttribute('customer_id_pagarme')->getValue();
-
-            $this->updateCustomerRequest->email = $customer->getEmail();
-            $this->updateCustomerRequest->name = $oldCustomer->getFirstName() . ' ' . $oldCustomer->getLastName();
-            $this->updateCustomerRequest->document = preg_replace('/[\/.-]/', '', $oldCustomer->getTaxvat());
-            $this->updateCustomerRequest->type = 'individual';
-
-            $this->getApi()->getCustomers()->updateCustomer($customerIdPagarme, $this->updateCustomerRequest);
-
+            $this->customerService->updateCustomerAtPagarme($customer);
         }
-
-    }
-
-    /**
-     * Singleton access to Customers controller
-     * @return Controllers\CustomersController The *Singleton* instance
-     */
-    public function getCustomers()
-    {
-        return Controllers\CustomersController::getInstance();
-    }
-
-    /**
-     * @return \PagarmeCoreApiLib\PagarmeCoreApiClient
-     */
-    public function getApi()
-    {
-        return new \PagarmeCoreApiLib\PagarmeCoreApiClient($this->config->getSecretKey(), '');
     }
 
 }

--- a/Helper/MultiBuyerDataAssign.php
+++ b/Helper/MultiBuyerDataAssign.php
@@ -1,0 +1,115 @@
+<?php
+    namespace Pagarme\Pagarme\Helper;
+
+    class MultiBuyerDataAssign {
+        
+        /**
+         * @param $info
+         * @param $additionalData
+        */
+        public function setCcMultiBuyer($info, $additionalData)
+        {
+            $info->setAdditionalInformation('cc_buyer_checkbox', $additionalData->getCcBuyerCheckbox());
+            if ($additionalData->getCcBuyerCheckbox()) {
+                $info->setAdditionalInformation('cc_buyer_name', $additionalData->getCcBuyerName());
+                $info->setAdditionalInformation('cc_buyer_email', $additionalData->getCcBuyerEmail());
+                $info->setAdditionalInformation('cc_buyer_document', $additionalData->getCcBuyerDocument());
+                $info->setAdditionalInformation('cc_buyer_street_title', $additionalData->getCcBuyerStreetTitle());
+                $info->setAdditionalInformation('cc_buyer_street_number', $additionalData->getCcBuyerStreetNumber());
+                $info->setAdditionalInformation('cc_buyer_street_complement', $additionalData->getCcBuyerStreetComplement());
+                $info->setAdditionalInformation('cc_buyer_zipcode', $additionalData->getCcBuyerZipcode());
+                $info->setAdditionalInformation('cc_buyer_neighborhood', $additionalData->getCcBuyerNeighborhood());
+                $info->setAdditionalInformation('cc_buyer_city', $additionalData->getCcBuyerCity());
+                $info->setAdditionalInformation('cc_buyer_state', $additionalData->getCcBuyerState());
+                $info->setAdditionalInformation('cc_buyer_home_phone', $additionalData->getCcBuyerHomePhone());
+                $info->setAdditionalInformation('cc_buyer_mobile_phone', $additionalData->getCcBuyerMobilePhone());
+            }
+        }
+
+        /**
+         * @param $info
+         * @param $additionalData
+        */
+        public function setBilletMultiBuyer($info, $additionalData)
+        {
+            $info->setAdditionalInformation('billet_buyer_checkbox', $additionalData->getBilletBuyerCheckbox());
+            if ($additionalData->getBilletBuyerCheckbox()) {
+                $info->setAdditionalInformation('billet_buyer_name', $additionalData->getBilletBuyerName());
+                $info->setAdditionalInformation('billet_buyer_email', $additionalData->getBilletBuyerEmail());
+                $info->setAdditionalInformation('billet_buyer_document', $additionalData->getBilletBuyerDocument());
+                $info->setAdditionalInformation('billet_buyer_street_title', $additionalData->getBilletBuyerStreetTitle());
+                $info->setAdditionalInformation('billet_buyer_street_number', $additionalData->getBilletBuyerStreetNumber());
+                $info->setAdditionalInformation('billet_buyer_street_complement', $additionalData->getBilletBuyerStreetComplement());
+                $info->setAdditionalInformation('billet_buyer_zipcode', $additionalData->getBilletBuyerZipcode());
+                $info->setAdditionalInformation('billet_buyer_neighborhood', $additionalData->getBilletBuyerNeighborhood());
+                $info->setAdditionalInformation('billet_buyer_city', $additionalData->getBilletBuyerCity());
+                $info->setAdditionalInformation('billet_buyer_state', $additionalData->getBilletBuyerState());
+                $info->setAdditionalInformation('billet_buyer_home_phone', $additionalData->getBilletBuyerHomePhone());
+                $info->setAdditionalInformation('billet_buyer_mobile_phone', $additionalData->getBilletBuyerMobilePhone());
+            }
+        }
+
+
+        /**
+         * @param $info
+         * @param $additionalData
+         */
+        public function setTwoCcMultiBuyer($info, $additionalData)
+        {
+            $info->setAdditionalInformation('cc_buyer_checkbox_first', $additionalData->getCcBuyerCheckboxFirst());
+            if ($additionalData->getCcBuyerCheckboxFirst()) {
+                $info->setAdditionalInformation('cc_buyer_name_first', $additionalData->getCcBuyerNameFirst());
+                $info->setAdditionalInformation('cc_buyer_email_first', $additionalData->getCcBuyerEmailFirst());
+                $info->setAdditionalInformation('cc_buyer_document_first', $additionalData->getCcBuyerDocumentFirst());
+                $info->setAdditionalInformation('cc_buyer_street_title_first', $additionalData->getCcBuyerStreetTitleFirst());
+                $info->setAdditionalInformation('cc_buyer_street_number_first', $additionalData->getCcBuyerStreetNumberFirst());
+                $info->setAdditionalInformation('cc_buyer_street_complement_first', $additionalData->getCcBuyerStreetComplementFirst());
+                $info->setAdditionalInformation('cc_buyer_zipcode_first', $additionalData->getCcBuyerZipcodeFirst());
+                $info->setAdditionalInformation('cc_buyer_neighborhood_first', $additionalData->getCcBuyerNeighborhoodFirst());
+                $info->setAdditionalInformation('cc_buyer_city_first', $additionalData->getCcBuyerCityFirst());
+                $info->setAdditionalInformation('cc_buyer_state_first', $additionalData->getCcBuyerStateFirst());
+                $info->setAdditionalInformation('cc_buyer_home_phone_first', $additionalData->getCcBuyerHomePhoneFirst());
+                $info->setAdditionalInformation('cc_buyer_mobile_phone_first', $additionalData->getCcBuyerMobilePhoneFirst());
+            }
+
+            $info->setAdditionalInformation('cc_buyer_checkbox_second', $additionalData->getCcBuyerCheckboxSecond());
+            if ($additionalData->getCcBuyerCheckboxSecond()) {
+                $info->setAdditionalInformation('cc_buyer_name_second', $additionalData->getCcBuyerNameSecond());
+                $info->setAdditionalInformation('cc_buyer_email_second', $additionalData->getCcBuyerEmailSecond());
+                $info->setAdditionalInformation('cc_buyer_document_second', $additionalData->getCcBuyerDocumentSecond());
+                $info->setAdditionalInformation('cc_buyer_street_title_second', $additionalData->getCcBuyerStreetTitleSecond());
+                $info->setAdditionalInformation('cc_buyer_street_number_second', $additionalData->getCcBuyerStreetNumberSecond());
+                $info->setAdditionalInformation('cc_buyer_street_complement_second', $additionalData->getCcBuyerStreetComplementSecond());
+                $info->setAdditionalInformation('cc_buyer_zipcode_second', $additionalData->getCcBuyerZipcodeSecond());
+                $info->setAdditionalInformation('cc_buyer_neighborhood_second', $additionalData->getCcBuyerNeighborhoodSecond());
+                $info->setAdditionalInformation('cc_buyer_city_second', $additionalData->getCcBuyerCitySecond());
+                $info->setAdditionalInformation('cc_buyer_state_second', $additionalData->getCcBuyerStateSecond());
+                $info->setAdditionalInformation('cc_buyer_home_phone_second', $additionalData->getCcBuyerHomePhoneSecond());
+                $info->setAdditionalInformation('cc_buyer_mobile_phone_second', $additionalData->getCcBuyerMobilePhoneSecond());
+            }
+        }
+
+        /**
+         * @param $info
+         * @param $additionalData
+         */
+        public function setPixMultibuyer($info, $additionalData)
+        {
+            $info->setAdditionalInformation('pix_buyer_checkbox', $additionalData->getPixBuyerCheckbox());
+            if ($additionalData->getPixBuyerCheckbox()) {
+                $info->setAdditionalInformation('pix_buyer_name', $additionalData->getPixBuyerName());
+                $info->setAdditionalInformation('pix_buyer_email', $additionalData->getPixBuyerEmail());
+                $info->setAdditionalInformation('pix_buyer_document', $additionalData->getPixBuyerDocument());
+                $info->setAdditionalInformation('pix_buyer_street_title', $additionalData->getPixBuyerStreetTitle());
+                $info->setAdditionalInformation('pix_buyer_street_number', $additionalData->getPixBuyerStreetNumber());
+                $info->setAdditionalInformation('pix_buyer_street_complement', $additionalData->getBilletBuyerStreetComplement());
+                $info->setAdditionalInformation('pix_buyer_zipcode', $additionalData->getPixBuyerZipcode());
+                $info->setAdditionalInformation('pix_buyer_neighborhood', $additionalData->getPixBuyerNeighborhood());
+                $info->setAdditionalInformation('pix_buyer_city', $additionalData->getPixBuyerCity());
+                $info->setAdditionalInformation('pix_buyer_state', $additionalData->getPixBuyerState());
+                $info->setAdditionalInformation('pix_buyer_home_phone', $additionalData->getPixBuyerHomePhone());
+                $info->setAdditionalInformation('pix_buyer_mobile_phone', $additionalData->getPixBuyerMobilePhone());
+            }
+        }
+    }
+

--- a/Helper/Payment/Billet.php
+++ b/Helper/Payment/Billet.php
@@ -6,6 +6,7 @@
     use Pagarme\Core\Kernel\ValueObjects\Id\SubscriptionId;
     use Pagarme\Core\Kernel\Repositories\OrderRepository;
     use Pagarme\Core\Recurrence\Repositories\ChargeRepository as SubscriptionChargeRepository;
+    use Pagarme\Core\Recurrence\Repositories\SubscriptionRepository;
 
     class Billet {
         
@@ -15,7 +16,7 @@
             if (strpos($method, "pagarme_billet") === false) {
                 return;
             }
-            $boletoUrl = $info->getAdditionalInformation('billet_url');
+            
             Magento2CoreSetup::bootstrap();
             $boletoUrl = $this->getBoletoLinkFromOrder($info);
 

--- a/Helper/Payment/Billet.php
+++ b/Helper/Payment/Billet.php
@@ -1,0 +1,81 @@
+<?php
+    namespace Pagarme\Pagarme\Helper\Payment;
+
+    use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
+    use Pagarme\Core\Kernel\ValueObjects\Id\OrderId;
+    use Pagarme\Core\Kernel\ValueObjects\Id\SubscriptionId;
+    use Pagarme\Core\Kernel\Repositories\OrderRepository;
+    use Pagarme\Core\Recurrence\Repositories\ChargeRepository as SubscriptionChargeRepository;
+
+    class Billet {
+        
+        public function getBilletUrl($info)
+        {
+            $method = $info->getMethod();
+            if (strpos($method, "pagarme_billet") === false) {
+                return;
+            }
+            $boletoUrl = $info->getAdditionalInformation('billet_url');
+            Magento2CoreSetup::bootstrap();
+            $boletoUrl = $this->getBoletoLinkFromOrder($info);
+
+            if (!$boletoUrl) {
+                $boletoUrl = $this->getBoletoLinkFromSubscription($info);
+            }
+    
+            return $boletoUrl;
+        }
+
+        private function getBoletoLinkFromOrder($info)
+        {
+            $lastTransId = $info->getLastTransId();
+            $orderId = null;
+            if ($lastTransId) {
+                $orderId = substr($lastTransId, 0, 19);
+            }
+
+            if (!$orderId) {
+                return null;
+            }
+
+            $orderRepository = new OrderRepository();
+            $order = $orderRepository->findByPagarmeId(new OrderId($orderId));
+
+            if ($order !== null) {
+                $charges = $order->getCharges();
+                foreach ($charges as $charge) {
+                    $transaction = $charge->getLastTransaction();
+                    $savedBoletoUrl = $transaction->getBoletoUrl();
+                    if ($savedBoletoUrl !== null) {
+                        $boletoUrl = $savedBoletoUrl;
+                    }
+                }
+            }
+
+            return $boletoUrl;
+        }
+
+        private function getBoletoLinkFromSubscription($info)
+        {
+            $subscriptionRepository = new SubscriptionRepository();
+            $subscription = $subscriptionRepository->findByCode($info->getOrder()->getIncrementId());
+
+            if (!$subscription) {
+                return null;
+            }
+
+            $chargeRepository = new SubscriptionChargeRepository();
+            $subscriptionId =
+                new SubscriptionId(
+                    $subscription->getPagarmeId()->getValue()
+                );
+
+            $charge = $chargeRepository->findBySubscriptionId($subscriptionId);
+
+            if (!empty($charge[0])) {
+                return $charge[0]->getBoletoUrl();
+            }
+
+            return null;
+        }
+    }

--- a/Helper/Payment/Pix.php
+++ b/Helper/Payment/Pix.php
@@ -1,0 +1,27 @@
+<?php
+    namespace Pagarme\Pagarme\Helper\Payment;
+
+    use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
+    use Pagarme\Core\Kernel\ValueObjects\Id\OrderId;
+    use Pagarme\Core\Payment\Services\OrderService;
+
+    class Pix {
+
+        public function getQrCode($info)
+        {
+            $orderId = null;
+            $method = $info->getMethod();
+            if (strpos($method, "pagarme_pix") === false) {
+                return null;
+            }
+
+            $lastTransId = $info->getLastTransId();
+            if ($lastTransId) {
+                $orderId = substr($lastTransId, 0, 19);
+            }
+
+            Magento2CoreSetup::bootstrap();
+            $orderService= new OrderService();
+            return $orderService->getPixQrCodeInfoFromOrder(new OrderId($orderId));
+        }
+    }

--- a/Model/PagarmeConfigProvider.php
+++ b/Model/PagarmeConfigProvider.php
@@ -118,7 +118,9 @@ class PagarmeConfigProvider implements ConfigProviderInterface
         if (
             !$isGatewayIntegrationType
             && mb_strlen($softDescription) > $maxSizeForPSP
+            && mb_strlen($softDescription) > $maxSizeForPSP
         ) {
+            $newResult = mb_substr($softDescription, 0, $maxSizeForPSP);
             $newResult = mb_substr($softDescription, 0, $maxSizeForPSP);
             $this->config->saveConfig(
                 self::XML_PATH_SOFT_DESCRIPTION,

--- a/Model/PagarmeConfigProvider.php
+++ b/Model/PagarmeConfigProvider.php
@@ -96,7 +96,7 @@ class PagarmeConfigProvider implements ConfigProviderInterface
     public function validateSoftDescription()
     {
         $isGatewayIntegrationType = $this->isGatewayIntegrationType();
-        $softDescription = $this->getSoftDescription();
+        $softDescription = $this->getSoftDescription() ?? "";
         $maxSizeForGateway = 22;
         $maxSizeForPSP = 13;
 

--- a/Observer/BilletCreditCardDataAssignObserver.php
+++ b/Observer/BilletCreditCardDataAssignObserver.php
@@ -20,6 +20,7 @@ use Magento\Framework\Event\Observer;
 use Magento\Quote\Api\Data\PaymentInterface;
 use Pagarme\Core\Payment\Repositories\SavedCardRepository;
 use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
+use Pagarme\Pagarme\Helper\MultiBuyerDataAssign;
 use Pagarme\Pagarme\Model\Cards;
 use Pagarme\Pagarme\Model\CardsRepository;
 
@@ -94,8 +95,10 @@ class BilletCreditCardDataAssignObserver extends AbstractDataAssignObserver
 
             $info->setAdditionalInformation('cc_savecard', $additionalData->getCcSavecard());
         }
-
-        $this->setMultiBuyer($info, $additionalData);
+      
+        $multiBuyerDataAssign = new MultiBuyerDataAssign();
+        $multiBuyerDataAssign->setCcMultiBuyer($info, $additionalData);
+        $multiBuyerDataAssign->setBilletMultiBuyer($info, $additionalData);
 
         $info->setAdditionalInformation('cc_installments', 1);
         $info->setAdditionalInformation('cc_cc_amount', $additionalData->getCcCcAmount());
@@ -107,41 +110,5 @@ class BilletCreditCardDataAssignObserver extends AbstractDataAssignObserver
 
         return $this;
     }
-
-    /**
-     * @param $info
-     * @param $additionalData
-     */
-    protected function setMultiBuyer($info, $additionalData)
-    {
-        $info->setAdditionalInformation('billet_buyer_checkbox', $additionalData->getBilletBuyerCheckbox());
-        $info->setAdditionalInformation('billet_buyer_name', $additionalData->getBilletBuyerName());
-        $info->setAdditionalInformation('billet_buyer_email', $additionalData->getBilletBuyerEmail());
-        $info->setAdditionalInformation('billet_buyer_document', $additionalData->getBilletBuyerDocument());
-        $info->setAdditionalInformation('billet_buyer_street_title', $additionalData->getBilletBuyerStreetTitle());
-        $info->setAdditionalInformation('billet_buyer_street_number', $additionalData->getBilletBuyerStreetNumber());
-        $info->setAdditionalInformation('billet_buyer_street_complement', $additionalData->getBilletBuyerStreetComplement());
-        $info->setAdditionalInformation('billet_buyer_zipcode', $additionalData->getBilletBuyerZipcode());
-        $info->setAdditionalInformation('billet_buyer_neighborhood', $additionalData->getBilletBuyerNeighborhood());
-        $info->setAdditionalInformation('billet_buyer_city', $additionalData->getBilletBuyerCity());
-        $info->setAdditionalInformation('billet_buyer_state', $additionalData->getBilletBuyerState());
-        $info->setAdditionalInformation('billet_buyer_home_phone', $additionalData->getBilletBuyerHomePhone());
-        $info->setAdditionalInformation('billet_buyer_mobile_phone', $additionalData->getBilletBuyerMobilePhone());
-
-        $info->setAdditionalInformation('cc_buyer_checkbox', $additionalData->getCcBuyerCheckbox());
-        $info->setAdditionalInformation('cc_buyer_name', $additionalData->getCcBuyerName());
-        $info->setAdditionalInformation('cc_buyer_email', $additionalData->getCcBuyerEmail());
-        $info->setAdditionalInformation('cc_buyer_document', $additionalData->getCcBuyerDocument());
-        $info->setAdditionalInformation('cc_buyer_street_title', $additionalData->getCcBuyerStreetTitle());
-        $info->setAdditionalInformation('cc_buyer_street_number', $additionalData->getCcBuyerStreetNumber());
-        $info->setAdditionalInformation('cc_buyer_street_complement', $additionalData->getCcBuyerStreetComplement());
-        $info->setAdditionalInformation('cc_buyer_zipcode', $additionalData->getCcBuyerZipcode());
-        $info->setAdditionalInformation('cc_buyer_neighborhood', $additionalData->getCcBuyerNeighborhood());
-        $info->setAdditionalInformation('cc_buyer_city', $additionalData->getCcBuyerCity());
-        $info->setAdditionalInformation('cc_buyer_state', $additionalData->getCcBuyerState());
-        $info->setAdditionalInformation('cc_buyer_home_phone', $additionalData->getCcBuyerHomePhone());
-        $info->setAdditionalInformation('cc_buyer_mobile_phone', $additionalData->getCcBuyerMobilePhone());
-    }
-
 
 }

--- a/Observer/BilletDataAssignObserver.php
+++ b/Observer/BilletDataAssignObserver.php
@@ -12,16 +12,11 @@
 namespace Pagarme\Pagarme\Observer;
 
 
-use Magento\Framework\App\ObjectManager;
 use Magento\Framework\DataObject;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Payment\Observer\AbstractDataAssignObserver;
 use Magento\Framework\Event\Observer;
 use Magento\Quote\Api\Data\PaymentInterface;
-use Pagarme\Core\Payment\Repositories\SavedCardRepository;
-use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
-use Pagarme\Pagarme\Model\Cards;
-use Pagarme\Pagarme\Model\CardsRepository;
+use Pagarme\Pagarme\Helper\MultiBuyerDataAssign;
 
 class BilletDataAssignObserver extends AbstractDataAssignObserver
 {
@@ -36,20 +31,8 @@ class BilletDataAssignObserver extends AbstractDataAssignObserver
         if (!is_object($additionalData)) {
             $additionalData = new DataObject($additionalData ?: []);
         }
-
-        $info->setAdditionalInformation('billet_buyer_checkbox', $additionalData->getBilletBuyerCheckbox());
-        $info->setAdditionalInformation('billet_buyer_name', $additionalData->getBilletBuyerName());
-        $info->setAdditionalInformation('billet_buyer_email', $additionalData->getBilletBuyerEmail());
-        $info->setAdditionalInformation('billet_buyer_document', $additionalData->getBilletBuyerDocument());
-        $info->setAdditionalInformation('billet_buyer_street_title', $additionalData->getBilletBuyerStreetTitle());
-        $info->setAdditionalInformation('billet_buyer_street_number', $additionalData->getBilletBuyerStreetNumber());
-        $info->setAdditionalInformation('billet_buyer_street_complement', $additionalData->getBilletBuyerStreetComplement());
-        $info->setAdditionalInformation('billet_buyer_zipcode', $additionalData->getBilletBuyerZipcode());
-        $info->setAdditionalInformation('billet_buyer_neighborhood', $additionalData->getBilletBuyerNeighborhood());
-        $info->setAdditionalInformation('billet_buyer_city', $additionalData->getBilletBuyerCity());
-        $info->setAdditionalInformation('billet_buyer_state', $additionalData->getBilletBuyerState());
-        $info->setAdditionalInformation('billet_buyer_home_phone', $additionalData->getBilletBuyerHomePhone());
-        $info->setAdditionalInformation('billet_buyer_mobile_phone', $additionalData->getBilletBuyerMobilePhone());
+        $multiBuyerDataAssign = new MultiBuyerDataAssign();
+        $multiBuyerDataAssign->setBilletMultiBuyer($info, $additionalData);
 
         return $this;
     }

--- a/Observer/CreditCardDataAssignObserver.php
+++ b/Observer/CreditCardDataAssignObserver.php
@@ -74,7 +74,9 @@ class CreditCardDataAssignObserver extends AbstractDataAssignObserver
         }else{
             $info->setAdditionalInformation('cc_saved_card', $additionalData->getCcSavedCard());
             $info->setAdditionalInformation('cc_type', $additionalData->getCcType());
-            $info->setAdditionalInformation('cc_last_4', substr($additionalData->getCcLast4(),-4));
+            if ($additionalData->getCcLast4()) {
+                $info->setAdditionalInformation('cc_last_4', substr($additionalData->getCcLast4(),-4));
+            }
             $info->setAdditionalInformation('cc_token_credit_card', $additionalData->getCcTokenCreditCard());
             $info->addData([
                 'cc_type' => $additionalData->getCcType(),

--- a/Observer/CreditCardDataAssignObserver.php
+++ b/Observer/CreditCardDataAssignObserver.php
@@ -22,6 +22,7 @@ use Pagarme\Core\Payment\Repositories\SavedCardRepository;
 use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
 use Pagarme\Pagarme\Model\Cards;
 use Pagarme\Pagarme\Model\CardsRepository;
+use Pagarme\Pagarme\Helper\MultiBuyerDataAssign;
 
 class CreditCardDataAssignObserver extends AbstractDataAssignObserver
 {
@@ -89,8 +90,9 @@ class CreditCardDataAssignObserver extends AbstractDataAssignObserver
 
             $info->setAdditionalInformation('cc_savecard', $additionalData->getCcSavecard());
         }
-
-        $this->setMultiBuyer($info, $additionalData);
+        $multiBuyerDataAssign = new MultiBuyerDataAssign();
+        $multiBuyerDataAssign->setCcMultiBuyer($info, $additionalData);
+        
         $info->setAdditionalInformation('cc_installments', 1);
 
         if ($additionalData->getCcInstallments()) {
@@ -100,26 +102,4 @@ class CreditCardDataAssignObserver extends AbstractDataAssignObserver
         return $this;
     }
 
-    /**
-     * @param $info
-     * @param $additionalData
-     */
-    protected function setMultiBuyer($info, $additionalData)
-    {
-        $info->setAdditionalInformation('cc_buyer_checkbox', $additionalData->getCcBuyerCheckbox());
-        if ($additionalData->getCcBuyerCheckbox()) {
-            $info->setAdditionalInformation('cc_buyer_name', $additionalData->getCcBuyerName());
-            $info->setAdditionalInformation('cc_buyer_email', $additionalData->getCcBuyerEmail());
-            $info->setAdditionalInformation('cc_buyer_document', $additionalData->getCcBuyerDocument());
-            $info->setAdditionalInformation('cc_buyer_street_title', $additionalData->getCcBuyerStreetTitle());
-            $info->setAdditionalInformation('cc_buyer_street_number', $additionalData->getCcBuyerStreetNumber());
-            $info->setAdditionalInformation('cc_buyer_street_complement', $additionalData->getCcBuyerStreetComplement());
-            $info->setAdditionalInformation('cc_buyer_zipcode', $additionalData->getCcBuyerZipcode());
-            $info->setAdditionalInformation('cc_buyer_neighborhood', $additionalData->getCcBuyerNeighborhood());
-            $info->setAdditionalInformation('cc_buyer_city', $additionalData->getCcBuyerCity());
-            $info->setAdditionalInformation('cc_buyer_state', $additionalData->getCcBuyerState());
-            $info->setAdditionalInformation('cc_buyer_home_phone', $additionalData->getCcBuyerHomePhone());
-            $info->setAdditionalInformation('cc_buyer_mobile_phone', $additionalData->getCcBuyerMobilePhone());
-        }
-    }
 }

--- a/Observer/CreditCardOrderPlaceBeforeObserver.php
+++ b/Observer/CreditCardOrderPlaceBeforeObserver.php
@@ -51,13 +51,17 @@ class CreditCardOrderPlaceBeforeObserver implements ObserverInterface
         if($payment->getMethod() == 'pagarme_creditcard'){
             $tax = $this->getTaxOrder(
                 $payment->getAdditionalInformation('cc_installments'),
-                $payment->getAdditionalInformation('cc_type'),
-                $order
+                $order,
+                $payment->getAdditionalInformation('cc_type')
             );
         }
 
         if($payment->getMethod() == 'pagarme_billet_creditcard'){
-            $tax = $this->getTaxOrderByAmount($payment->getAdditionalInformation('cc_installments'), $payment->getCcType(), $payment->getAdditionalInformation('cc_cc_amount'));
+            $tax = $this->getTaxOrderByAmount(
+                $payment->getAdditionalInformation('cc_installments'),
+                $payment->getAdditionalInformation('cc_cc_amount'),
+                $payment->getCcType()
+            );
         }
 
         if($payment->getMethod() == 'pagarme_two_creditcard'){
@@ -71,7 +75,7 @@ class CreditCardOrderPlaceBeforeObserver implements ObserverInterface
         return $this;
     }
 
-    protected function getTaxOrder($installments, $type = null, $order)
+    protected function getTaxOrder($installments, $order, $type = null)
     {
         $installmentService = new InstallmentService();
 
@@ -98,7 +102,7 @@ class CreditCardOrderPlaceBeforeObserver implements ObserverInterface
         return $result;
     }
 
-    protected function getTaxOrderByAmount($installments, $type = null, $amount)
+    protected function getTaxOrderByAmount($installments, $amount, $type = null)
     {
         $returnInstallments = $this->getInstallmentsByBrandAndAmountInterface()->getInstallmentsByBrandAndAmount($type,$amount);
         $result = 0;

--- a/Observer/CustomerAddressSaveBefore.php
+++ b/Observer/CustomerAddressSaveBefore.php
@@ -62,7 +62,7 @@ class CustomerAddressSaveBefore implements ObserverInterface
             throw new InputException(__("Please check your address. Country is required."));
         }
 
-        if (empty($customerAddress->getName()) || $customerAddress->getName() > 65) {
+        if (empty($customerAddress->getName()) || strlen($customerAddress->getName()) > 65) {
             throw new InputException(__("Please check your address. Name and firstname are required."));
         }
 

--- a/Observer/DebitDataAssignObserver.php
+++ b/Observer/DebitDataAssignObserver.php
@@ -61,7 +61,9 @@ class DebitDataAssignObserver extends AbstractDataAssignObserver
     {
         $info->setAdditionalInformation('cc_saved_card', $additionalData->getCcSavedCard());
         $info->setAdditionalInformation('cc_type', $additionalData->getCcType());
-        $info->setAdditionalInformation('cc_last_4', substr($additionalData->getCcLast4(),-4));
+        if ($additionalData->getCcLast4()) {
+            $info->setAdditionalInformation('cc_last_4', substr($additionalData->getCcLast4(),-4));
+        }
         $info->setAdditionalInformation('cc_token_credit_card', $additionalData->getCcTokenCreditCard());
         $info->addData([
             'cc_type' => $additionalData->getCcType(),

--- a/Observer/DebitDataAssignObserver.php
+++ b/Observer/DebitDataAssignObserver.php
@@ -10,6 +10,7 @@ use Magento\Framework\Event\Observer;
 use Magento\Quote\Api\Data\PaymentInterface;
 use Pagarme\Core\Payment\Repositories\SavedCardRepository;
 use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
+use Pagarme\Pagarme\Helper\MultiBuyerDataAssign;
 use Pagarme\Pagarme\Model\Cards;
 use Pagarme\Pagarme\Model\CardsRepository;
 
@@ -46,7 +47,9 @@ class DebitDataAssignObserver extends AbstractDataAssignObserver
 
         $info->setAdditionalInformation('cc_saved_card', '0');
         $info->setAdditionalInformation('cc_installments', 1);
-        $this->setMultiBuyer($info, $additionalData);
+        
+        $multiBuyerDataAssign = new MultiBuyerDataAssign();
+        $multiBuyerDataAssign->setCcMultiBuyer($info, $additionalData);
 
         if ($additionalData->getCcSavedCard()) {
             $this->setSavedCardAdditionalData($info, $additionalData);
@@ -76,6 +79,7 @@ class DebitDataAssignObserver extends AbstractDataAssignObserver
 
         $info->setAdditionalInformation('cc_savecard', $additionalData->getCcSavecard());
     }
+
     protected function setSavedCardAdditionalData($info, $additionalData)
     {
         $cardId = $additionalData->getCcSavedCard();
@@ -94,26 +98,4 @@ class DebitDataAssignObserver extends AbstractDataAssignObserver
         ]);
     }
 
-    /**
-     * @param $info
-     * @param $additionalData
-     */
-    protected function setMultiBuyer($info, $additionalData)
-    {
-        $info->setAdditionalInformation('cc_buyer_checkbox', $additionalData->getCcBuyerCheckbox());
-        if ($additionalData->getCcBuyerCheckbox()) {
-            $info->setAdditionalInformation('cc_buyer_name', $additionalData->getCcBuyerName());
-            $info->setAdditionalInformation('cc_buyer_email', $additionalData->getCcBuyerEmail());
-            $info->setAdditionalInformation('cc_buyer_document', $additionalData->getCcBuyerDocument());
-            $info->setAdditionalInformation('cc_buyer_street_title', $additionalData->getCcBuyerStreetTitle());
-            $info->setAdditionalInformation('cc_buyer_street_number', $additionalData->getCcBuyerStreetNumber());
-            $info->setAdditionalInformation('cc_buyer_street_complement', $additionalData->getCcBuyerStreetComplement());
-            $info->setAdditionalInformation('cc_buyer_zipcode', $additionalData->getCcBuyerZipcode());
-            $info->setAdditionalInformation('cc_buyer_neighborhood', $additionalData->getCcBuyerNeighborhood());
-            $info->setAdditionalInformation('cc_buyer_city', $additionalData->getCcBuyerCity());
-            $info->setAdditionalInformation('cc_buyer_state', $additionalData->getCcBuyerState());
-            $info->setAdditionalInformation('cc_buyer_home_phone', $additionalData->getCcBuyerHomePhone());
-            $info->setAdditionalInformation('cc_buyer_mobile_phone', $additionalData->getCcBuyerMobilePhone());
-        }
-    }
 }

--- a/Observer/PaymentMethodAvailable.php
+++ b/Observer/PaymentMethodAvailable.php
@@ -114,21 +114,19 @@ class PaymentMethodAvailable implements ObserverInterface
             return $pagarmePaymentsMethods;
         }
 
-        $pagarmePaymentsMethodsFlip = array_flip($pagarmePaymentsMethods);
-
         $methodsAvailable = [];
         foreach ($recurrenceProducts as $recurrenceProduct) {
 
             if (
                 $recurrenceProduct->getCreditCard() &&
-                in_array('pagarme_creditcard', $pagarmePaymentsMethodsFlip)
+                in_array('pagarme_creditcard', $pagarmePaymentsMethods)
             ) {
                 $methodsAvailable[] = 'pagarme_creditcard';
             }
 
             if (
                 $recurrenceProduct->getBoleto() &&
-                in_array('pagarme_billet', $pagarmePaymentsMethodsFlip)
+                in_array('pagarme_billet', $pagarmePaymentsMethods)
             ) {
                 $methodsAvailable[] = 'pagarme_billet';
             }

--- a/Observer/PixDataAssignObserver.php
+++ b/Observer/PixDataAssignObserver.php
@@ -10,6 +10,7 @@ use Magento\Framework\Event\Observer;
 use Magento\Quote\Api\Data\PaymentInterface;
 use Pagarme\Core\Payment\Repositories\SavedCardRepository;
 use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
+use Pagarme\Pagarme\Helper\MultiBuyerDataAssign;
 use Pagarme\Pagarme\Model\Cards;
 use Pagarme\Pagarme\Model\CardsRepository;
 
@@ -27,19 +28,8 @@ class PixDataAssignObserver extends AbstractDataAssignObserver
             $additionalData = new DataObject($additionalData ?: []);
         }
 
-        $info->setAdditionalInformation('pix_buyer_checkbox', $additionalData->getBilletBuyerCheckbox());
-        $info->setAdditionalInformation('pix_buyer_name', $additionalData->getBilletBuyerName());
-        $info->setAdditionalInformation('pix_buyer_email', $additionalData->getBilletBuyerEmail());
-        $info->setAdditionalInformation('pix_buyer_document', $additionalData->getBilletBuyerDocument());
-        $info->setAdditionalInformation('pix_buyer_street_title', $additionalData->getBilletBuyerStreetTitle());
-        $info->setAdditionalInformation('pix_buyer_street_number', $additionalData->getBilletBuyerStreetNumber());
-        $info->setAdditionalInformation('pix_buyer_street_complement', $additionalData->getBilletBuyerStreetComplement());
-        $info->setAdditionalInformation('pix_buyer_zipcode', $additionalData->getBilletBuyerZipcode());
-        $info->setAdditionalInformation('pix_buyer_neighborhood', $additionalData->getBilletBuyerNeighborhood());
-        $info->setAdditionalInformation('pix_buyer_city', $additionalData->getBilletBuyerCity());
-        $info->setAdditionalInformation('pix_buyer_state', $additionalData->getBilletBuyerState());
-        $info->setAdditionalInformation('pix_buyer_home_phone', $additionalData->getBilletBuyerHomePhone());
-        $info->setAdditionalInformation('pix_buyer_mobile_phone', $additionalData->getBilletBuyerMobilePhone());
+        $multiBuyerDataAssign = new MultiBuyerDataAssign();
+        $multiBuyerDataAssign->setPixMultibuyer($info, $additionalData);
 
         return $this;
     }

--- a/Observer/TwoCreditCardDataAssignObserver.php
+++ b/Observer/TwoCreditCardDataAssignObserver.php
@@ -20,6 +20,7 @@ use Magento\Framework\Event\Observer;
 use Magento\Quote\Api\Data\PaymentInterface;
 use Pagarme\Core\Payment\Repositories\SavedCardRepository;
 use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
+use Pagarme\Pagarme\Helper\MultiBuyerDataAssign;
 use Pagarme\Pagarme\Model\Cards;
 use Pagarme\Pagarme\Model\CardsRepository;
 
@@ -131,7 +132,8 @@ class TwoCreditCardDataAssignObserver extends AbstractDataAssignObserver
             $info->setAdditionalInformation('cc_savecard_second', $additionalData->getCcSavecardSecond());
         }
 
-        $this->setMultiBuyer($info, $additionalData);
+        $multiBuyerDataAssign = new MultiBuyerDataAssign(); 
+        $multiBuyerDataAssign->setTwoCcMultiBuyer($info, $additionalData);
 
         $info->setAdditionalInformation('cc_installments_first', 1);
         $info->setAdditionalInformation('cc_installments_second', 1);
@@ -147,42 +149,5 @@ class TwoCreditCardDataAssignObserver extends AbstractDataAssignObserver
         return $this;
     }
 
-    /**
-     * @param $info
-     * @param $additionalData
-     */
-    protected function setMultiBuyer($info, $additionalData)
-    {
-        $info->setAdditionalInformation('cc_buyer_checkbox_first', $additionalData->getCcBuyerCheckboxFirst());
-        if ($additionalData->getCcBuyerCheckboxFirst()) {
-            $info->setAdditionalInformation('cc_buyer_name_first', $additionalData->getCcBuyerNameFirst());
-            $info->setAdditionalInformation('cc_buyer_email_first', $additionalData->getCcBuyerEmailFirst());
-            $info->setAdditionalInformation('cc_buyer_document_first', $additionalData->getCcBuyerDocumentFirst());
-            $info->setAdditionalInformation('cc_buyer_street_title_first', $additionalData->getCcBuyerStreetTitleFirst());
-            $info->setAdditionalInformation('cc_buyer_street_number_first', $additionalData->getCcBuyerStreetNumberFirst());
-            $info->setAdditionalInformation('cc_buyer_street_complement_first', $additionalData->getCcBuyerStreetComplementFirst());
-            $info->setAdditionalInformation('cc_buyer_zipcode_first', $additionalData->getCcBuyerZipcodeFirst());
-            $info->setAdditionalInformation('cc_buyer_neighborhood_first', $additionalData->getCcBuyerNeighborhoodFirst());
-            $info->setAdditionalInformation('cc_buyer_city_first', $additionalData->getCcBuyerCityFirst());
-            $info->setAdditionalInformation('cc_buyer_state_first', $additionalData->getCcBuyerStateFirst());
-            $info->setAdditionalInformation('cc_buyer_home_phone_first', $additionalData->getCcBuyerHomePhoneFirst());
-            $info->setAdditionalInformation('cc_buyer_mobile_phone_first', $additionalData->getCcBuyerMobilePhoneFirst());
-        }
-
-        $info->setAdditionalInformation('cc_buyer_checkbox_second', $additionalData->getCcBuyerCheckboxSecond());
-        if ($additionalData->getCcBuyerCheckboxSecond()) {
-            $info->setAdditionalInformation('cc_buyer_name_second', $additionalData->getCcBuyerNameSecond());
-            $info->setAdditionalInformation('cc_buyer_email_second', $additionalData->getCcBuyerEmailSecond());
-            $info->setAdditionalInformation('cc_buyer_document_second', $additionalData->getCcBuyerDocumentSecond());
-            $info->setAdditionalInformation('cc_buyer_street_title_second', $additionalData->getCcBuyerStreetTitleSecond());
-            $info->setAdditionalInformation('cc_buyer_street_number_second', $additionalData->getCcBuyerStreetNumberSecond());
-            $info->setAdditionalInformation('cc_buyer_street_complement_second', $additionalData->getCcBuyerStreetComplementSecond());
-            $info->setAdditionalInformation('cc_buyer_zipcode_second', $additionalData->getCcBuyerZipcodeSecond());
-            $info->setAdditionalInformation('cc_buyer_neighborhood_second', $additionalData->getCcBuyerNeighborhoodSecond());
-            $info->setAdditionalInformation('cc_buyer_city_second', $additionalData->getCcBuyerCitySecond());
-            $info->setAdditionalInformation('cc_buyer_state_second', $additionalData->getCcBuyerStateSecond());
-            $info->setAdditionalInformation('cc_buyer_home_phone_second', $additionalData->getCcBuyerHomePhoneSecond());
-            $info->setAdditionalInformation('cc_buyer_mobile_phone_second', $additionalData->getCcBuyerMobilePhoneSecond());
-        }
-    }
+    
 }

--- a/Observer/VoucherDataAssignObserver.php
+++ b/Observer/VoucherDataAssignObserver.php
@@ -10,6 +10,7 @@ use Magento\Framework\Event\Observer;
 use Magento\Quote\Api\Data\PaymentInterface;
 use Pagarme\Core\Payment\Repositories\SavedCardRepository;
 use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
+use Pagarme\Pagarme\Helper\MultiBuyerDataAssign;
 use Pagarme\Pagarme\Model\Cards;
 use Pagarme\Pagarme\Model\CardsRepository;
 
@@ -46,7 +47,9 @@ class VoucherDataAssignObserver extends AbstractDataAssignObserver
 
         $info->setAdditionalInformation('cc_saved_card', '0');
         $info->setAdditionalInformation('cc_installments', 1);
-        $this->setMultiBuyer($info, $additionalData);
+
+        $multiBuyerDataAssign = new MultiBuyerDataAssign();
+        $multiBuyerDataAssign->setCcMultiBuyer($info, $additionalData);
 
         if ($additionalData->getCcSavedCard()) {
             $this->setSavedCardAdditionalData($info, $additionalData);
@@ -93,26 +96,4 @@ class VoucherDataAssignObserver extends AbstractDataAssignObserver
         ]);
     }
 
-    /**
-     * @param $info
-     * @param $additionalData
-     */
-    protected function setMultiBuyer($info, $additionalData)
-    {
-        $info->setAdditionalInformation('cc_buyer_checkbox', $additionalData->getCcBuyerCheckbox());
-        if ($additionalData->getCcBuyerCheckbox()) {
-            $info->setAdditionalInformation('cc_buyer_name', $additionalData->getCcBuyerName());
-            $info->setAdditionalInformation('cc_buyer_email', $additionalData->getCcBuyerEmail());
-            $info->setAdditionalInformation('cc_buyer_document', $additionalData->getCcBuyerDocument());
-            $info->setAdditionalInformation('cc_buyer_street_title', $additionalData->getCcBuyerStreetTitle());
-            $info->setAdditionalInformation('cc_buyer_street_number', $additionalData->getCcBuyerStreetNumber());
-            $info->setAdditionalInformation('cc_buyer_street_complement', $additionalData->getCcBuyerStreetComplement());
-            $info->setAdditionalInformation('cc_buyer_zipcode', $additionalData->getCcBuyerZipcode());
-            $info->setAdditionalInformation('cc_buyer_neighborhood', $additionalData->getCcBuyerNeighborhood());
-            $info->setAdditionalInformation('cc_buyer_city', $additionalData->getCcBuyerCity());
-            $info->setAdditionalInformation('cc_buyer_state', $additionalData->getCcBuyerState());
-            $info->setAdditionalInformation('cc_buyer_home_phone', $additionalData->getCcBuyerHomePhone());
-            $info->setAdditionalInformation('cc_buyer_mobile_phone', $additionalData->getCcBuyerMobilePhone());
-        }
-    }
 }

--- a/Observer/VoucherDataAssignObserver.php
+++ b/Observer/VoucherDataAssignObserver.php
@@ -61,7 +61,7 @@ class VoucherDataAssignObserver extends AbstractDataAssignObserver
     {
         $info->setAdditionalInformation('cc_saved_card', $additionalData->getCcSavedCard());
         $info->setAdditionalInformation('cc_type', $additionalData->getCcType());
-        $info->setAdditionalInformation('cc_last_4', substr($additionalData->getCcLast4(),-4));
+        $info->setAdditionalInformation('cc_last_4', substr($additionalData->getCcLast4() ?? '',-4));
         $info->setAdditionalInformation('cc_token_credit_card', $additionalData->getCcTokenCreditCard());
         $info->addData([
             'cc_type' => $additionalData->getCcType(),

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Coming soon :construction:
 composer require pagarme/pagarme-magento2-module
 
 ## Requirements
-* PHP >= 7.1 & <= 7.4
-* Magento2 >= 2.3 & <= 2.4.3
+* PHP >= 8.0
+* Magento2 >= 2.4.4
 
 ## Configuration
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "pagarme/pagarme-magento2-module",
     "license": "MIT",
-    "version": "1.2.1",
+    "version": "2.0.6",
     "type": "magento2-module",
     "description": "Magento 2 Module Pagar.me",
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
     "name": "pagarme/pagarme-magento2-module",
     "license": "MIT",
-    "version": "2.0.6",
+    "version": "2.1.0",
     "type": "magento2-module",
     "description": "Magento 2 Module Pagar.me",
     "require": {
-        "php": "~7.1",
+        "php": ">=7.1",
         "pagarme/pagarmecoreapi": "^5.7",
-        "pagarme/ecommerce-module-core": "~1.2.0"
+        "pagarme/ecommerce-module-core": "dev-develop"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.0",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.0",
-        "squizlabs/php_codesniffer": "2.7.0",
+        "squizlabs/php_codesniffer": "2.8.1",
         "phpmd/phpmd": "@stable",
         "pdepend/pdepend": "2.2.2",
         "sjparkinson/static-review": "~4.1",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -9,7 +9,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Pagarme_Pagarme" setup_version="1.2.1">
+    <module name="Pagarme_Pagarme" setup_version="2.0.6">
         <sequence>
             <module name="Magento_Sales" />
             <module name="Magento_Payment" />

--- a/view/adminhtml/templates/info/billetCreditCard.phtml
+++ b/view/adminhtml/templates/info/billetCreditCard.phtml
@@ -62,7 +62,7 @@ if (array_key_exists('billet', $lastTransactions)) {
     <br/>
 <?php } ?>
 
-<?php if ($this->getBilletUrl() && $this->getInfo()->getOrder()->getState() == 'pending_payment'): ?>
+<?php if ($this->getBilletUrl() && $this->getInfo()->getOrder()->getState() == 'new'): ?>
     <span><b><?php echo __('Amount') ?>: </b><?php echo 'R$ ' . number_format($this->getBilletAmount(), 2, ',', '.'); ?></span>
     <br/>
     <br/>

--- a/view/adminhtml/templates/info/pix.phtml
+++ b/view/adminhtml/templates/info/pix.phtml
@@ -31,12 +31,13 @@ if (!empty($lastTransaction)) {
     <br/>
 <?php } ?>
 
-<?php if ($this->getPixUrl() && $this->getInfo()->getOrder()->getStatus() == 'pending'): ?>
+<?php if ($this->getPixInfo() && $this->getInfo()->getOrder()->getStatus() == 'pending'): ?>
     <span><?php echo __($this->getTitle()) ?></span>
     <hr/>
-    <a class="action tocart primary" href="<?php echo $this->getPixUrl() ?>"
+    <img  width="100px" height="100px" src="<?php echo $this->getPixInfo()['qr_code_url'];?>"/>
+    <br/>
+    <a class="action tocart primary" href="<?php echo $this->getPixInfo()['qr_code_url'] ?>"
        target="_blank"><?php echo __('Print QrCode') ?></a>
 <?php else: ?>
     <span><?php echo __($this->getTitle()) ?></span>
 <?php endif ?>
-

--- a/view/adminhtml/templates/info/pix.phtml
+++ b/view/adminhtml/templates/info/pix.phtml
@@ -34,7 +34,7 @@ if (!empty($lastTransaction)) {
 <?php if ($this->getPixInfo() && $this->getInfo()->getOrder()->getStatus() == 'pending'): ?>
     <span><?php echo __($this->getTitle()) ?></span>
     <hr/>
-    <img  width="100px" height="100px" src="<?php echo $this->getPixInfo()['qr_code_url'];?>"/>
+    <img alt="Pix QrCode" width="100px" height="100px" src="<?php echo $this->getPixInfo()['qr_code_url'];?>"/>
     <br/>
     <a class="action tocart primary" href="<?php echo $this->getPixInfo()['qr_code_url'] ?>"
        target="_blank"><?php echo __('Print QrCode') ?></a>

--- a/view/frontend/web/js/core/checkout/PaymentMethodController.js
+++ b/view/frontend/web/js/core/checkout/PaymentMethodController.js
@@ -473,7 +473,7 @@ PaymentMethodController.prototype.addCreditCardInstallmentsListener = function (
 PaymentMethodController.prototype.addSavedCreditCardsListener = function(formObject) {
 
     var paymentMethodController = this;
-    var selector = formObject.savedCreditCardSelect.selector;
+    var selector = formObject.savedCreditCardSelect;
     var brand = jQuery(selector + ' option:selected').attr('brand');
 
     if (brand == undefined) {
@@ -755,9 +755,9 @@ PaymentMethodController.prototype.fillSavedCreditCardsSelect = function (formObj
     formHandler.init(formObject);
     formHandler.fillSavedCreditCardsSelect(platformConfig, formObject);
 
-    if (typeof formObject.savedCreditCardSelect.selector != 'undefined') {
+    if (typeof formObject.savedCreditCardSelect != 'undefined') {
 
-        selector = formObject.savedCreditCardSelect.selector;
+        selector = formObject.savedCreditCardSelect;
         var brand = jQuery(selector + ' option:selected').attr('brand');
 
         if (brand == undefined) {
@@ -791,7 +791,7 @@ PaymentMethodController.prototype.removeMultibuyerForm = function (formObject) {
 };
 
 PaymentMethodController.prototype.addShowMultibuyerListener = function(formObject) {
-    jQuery(formObject.multibuyer.showMultibuyer.selector).on('click', function () {
+    jQuery(formObject.multibuyer.showMultibuyer).on('click', function () {
         formHandler.init(formObject);
         formHandler.toggleMultibuyer(formObject);
     });

--- a/view/frontend/web/js/core/checkout/PaymentMethodController.js
+++ b/view/frontend/web/js/core/checkout/PaymentMethodController.js
@@ -473,8 +473,7 @@ PaymentMethodController.prototype.addCreditCardInstallmentsListener = function (
 PaymentMethodController.prototype.addSavedCreditCardsListener = function(formObject) {
 
     var paymentMethodController = this;
-    var selector = formObject.savedCreditCardSelect;
-    var brand = jQuery(selector + ' option:selected').attr('brand');
+    var brand = jQuery('option:selected').attr('brand');
 
     if (brand == undefined) {
         brand = formObject.creditCardBrand.val();
@@ -485,7 +484,7 @@ PaymentMethodController.prototype.addSavedCreditCardsListener = function(formObj
 
     formObject.savedCreditCardSelect.on('change', function() {
         var value = jQuery(this).val();
-        var brand = jQuery(selector + ' option:selected').attr('brand');
+        var brand = jQuery('option:selected').attr('brand');
 
         formObject.creditCardBrand.val(brand);
         if (value === 'new') {
@@ -755,10 +754,9 @@ PaymentMethodController.prototype.fillSavedCreditCardsSelect = function (formObj
     formHandler.init(formObject);
     formHandler.fillSavedCreditCardsSelect(platformConfig, formObject);
 
-    if (typeof formObject.savedCreditCardSelect != 'undefined') {
+    if (typeof formObject.savedCreditCardSelect[0] != 'undefined') {
 
-        selector = formObject.savedCreditCardSelect;
-        var brand = jQuery(selector + ' option:selected').attr('brand');
+        var brand = jQuery('option:selected').attr('brand');
 
         if (brand == undefined) {
             brand = formObject.creditCardBrand.val();

--- a/view/frontend/web/js/core/checkout/PaymentMethodController.js
+++ b/view/frontend/web/js/core/checkout/PaymentMethodController.js
@@ -395,7 +395,7 @@ PaymentMethodController.prototype.addCreditCardNumberListener = function(formObj
         setTimeout(function() {
             paymentMethodController.setBin(binObj,  element, formObject);
         }, 300);
-    }).bind(this);
+    });
 };
 
 PaymentMethodController.prototype.twoCardsTotal = function (paymentMethod) {

--- a/view/frontend/web/js/core/checkout/PaymentMethodController.js
+++ b/view/frontend/web/js/core/checkout/PaymentMethodController.js
@@ -399,8 +399,8 @@ PaymentMethodController.prototype.addCreditCardNumberListener = function(formObj
 };
 
 PaymentMethodController.prototype.twoCardsTotal = function (paymentMethod) {
-    var card1 = paymentMethod.formObject[0].creditCardInstallments.selector;
-    var card2 = paymentMethod.formObject[1].creditCardInstallments.selector;
+    var card1 = paymentMethod.formObject[0].creditCardInstallments;
+    var card2 = paymentMethod.formObject[1].creditCardInstallments;
 
     var totalCard1 = paymentMethod.formObject[0].inputAmount.val().replace(platformConfig.currency.decimalSeparator, ".");
     var totalCard2 = paymentMethod.formObject[1].inputAmount.val().replace(platformConfig.currency.decimalSeparator, ".");
@@ -418,7 +418,7 @@ PaymentMethodController.prototype.twoCardsTotal = function (paymentMethod) {
 }
 
 PaymentMethodController.prototype.boletoCreditCardTotal = function (paymentMethod) {
-    var cardElement = paymentMethod.formObject[1].creditCardInstallments.selector;
+    var cardElement = paymentMethod.formObject[1].creditCardInstallments;
 
     var sumInterestTotal = jQuery(cardElement).find(":selected").attr("interest");
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-288
| **What?**         | Adjusting compatibility between php 7 and php 8
| **Why?**          | To unify php7 and php8 deployments and avoid rework
| **How?**          | Adding the #[\ReturnTypeWillChange] attribute and delegating the client update function to the ecommerce module core

