### PR TITLE
PAOPN-258: error accessing subscription details

### DIFF
--- a/view/adminhtml/templates/recurrence/subscriptions/details.phtml
+++ b/view/adminhtml/templates/recurrence/subscriptions/details.phtml
@@ -89,7 +89,7 @@
                         <tr>
                             <th><?= __('Customer id') ?></th>
                             <td>
-                                <span><?= $subscription->getPlatformOrder()->getCustomer()->getPagarmeId()->getValue(); ?></span>
+                                <span><?= $subscription->getPlatformOrder()->getCustomer()->getPagarmeId(); ?></span>
                             </td>
                         </tr><tr>
                             <th><?= __('Customer name') ?></th>
@@ -234,7 +234,7 @@
                 </td>
                 <td>
                     <?php
-                        $cancelUrl = $charge->getBoletoUrl();
+                        $cancelUrl = $charge->getBoletoUrl() ?? "";
                         if (strlen($cancelUrl) > 0) {
                     ?>
                         <div class="data-grid-cell-content"> <?= $cancelUrl; ?> </div>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-258
| **What?**         | Fix bugs in subscription details
| **Why?**          | Fix bugs in subscription details
| **How?**          | Remove ->getValue and assign it empty to $cancelUrl if no billet link
