### PR TITLE
Fix split rule

### DIFF
--- a/Helper/Marketplace/Traits/SplitExtrasAndDiscountsRuleTrait.php
+++ b/Helper/Marketplace/Traits/SplitExtrasAndDiscountsRuleTrait.php
@@ -46,7 +46,8 @@ trait SplitExtrasAndDiscountsRuleTrait
         );
     }
 
-    private function calculateAmountOnlyForSeller($seller, $amount, $marketplaceTotal){
+    private function calculateAmountOnlyForSeller($seller, $amount, $marketplaceTotal)
+    {
         $sellerCommission = $seller['commission'];
         $sellerExtrasAndDiscountsPercentage =
             $sellerCommission / ($this->productTotal - $marketplaceTotal);
@@ -164,7 +165,8 @@ trait SplitExtrasAndDiscountsRuleTrait
     ) {
         foreach ($splitData['sellers'] as $key => &$seller) {
             $amountForSeller = $this->calculateAmountOnlyForSeller(
-                $seller, $amount, $splitData['marketplace']['totalCommission']);
+                $seller, $amount, $splitData['marketplace']['totalCommission']
+            );
                 
             $seller['commission'] += $amountForSeller;
         }

--- a/Helper/Marketplace/Traits/SplitExtrasAndDiscountsRuleTrait.php
+++ b/Helper/Marketplace/Traits/SplitExtrasAndDiscountsRuleTrait.php
@@ -30,7 +30,9 @@ trait SplitExtrasAndDiscountsRuleTrait
         $marketplaceExtrasAndDiscountsPercentage =
             $this->getPercentageOfTotalPaidPerEntity($marketplaceCommission);
         
-        return $marketplaceExtrasAndDiscountsPercentage * $amount;
+        return intval(
+            $marketplaceExtrasAndDiscountsPercentage * $amount
+        );
     }
 
     private function calculateAmountForSeller($seller, $amount)
@@ -39,7 +41,9 @@ trait SplitExtrasAndDiscountsRuleTrait
         $sellerExtrasAndDiscountsPercentage =
             $this->getPercentageOfTotalPaidPerEntity($sellerCommission);
 
-        return $sellerExtrasAndDiscountsPercentage * $amount;
+        return intval(
+            $sellerExtrasAndDiscountsPercentage * $amount
+        );
     }
 
     private function calculateAmountOnlyForSeller($seller, $amount, $marketplaceTotal){

--- a/Helper/Marketplace/WebkulHelper.php
+++ b/Helper/Marketplace/WebkulHelper.php
@@ -196,8 +196,8 @@ class WebkulHelper
                 $totalPaid,
                 $productTotal
             );
-
-        if (empty($extraOrDiscountTotal)) {
+            
+        if (empty($extraOrDiscountTotal) && $extraOrDiscountTotal != 0) {
             return $splitData;
         }
 
@@ -218,14 +218,12 @@ class WebkulHelper
         $splitData['sellers'] = [];
         $splitData['marketplace']['totalCommission'] = 0;
         $totalPaidProductWithoutSeller = 0;
-        $total = 0;
         foreach ($orderItems as $item) {
             $productId = $item->getProductId();
             $itemPrice = $this->moneyService->floatToCents(
                 $item->getRowTotal()
             );
 
-            $total += $itemPrice;
             $sellerAndCommisions = $this->getSellerAndCommissions(
                 $itemPrice,
                 $productId
@@ -235,7 +233,7 @@ class WebkulHelper
                 $totalPaidProductWithoutSeller += $itemPrice;
                 continue;
             }
-            // 
+
             $this->addCommissionsToSplitData(
                 $sellerAndCommisions,
                 $splitData
@@ -248,7 +246,6 @@ class WebkulHelper
         }
         $splitData['marketplace']['totalCommission']
         += $totalPaidProductWithoutSeller;
-        $splitData = $this->handleRemainder($splitData,  $totalPaidProductWithoutSeller, $total);
         
         $splitData = $this->handleExtrasAndDiscounts(
             $corePlatformOrderDecorator,

--- a/Helper/Marketplace/WebkulHelper.php
+++ b/Helper/Marketplace/WebkulHelper.php
@@ -154,23 +154,6 @@ class WebkulHelper
             += $sellerAndCommisions['marketplaceCommission'];
     }
 
-    private function handleRemainder(&$splitData, $totalPaidProductWithoutSeller, $totalPaid)
-    {
-        $remainder = $this->splitRemainderHandler->calculateRemainder(
-            $splitData,
-            $totalPaidProductWithoutSeller,
-            $totalPaid
-        );
-
-        if ($remainder == 0) {
-            return $splitData;
-        }
-
-        return $this->splitRemainderHandler->setRemainderToResponsible(
-            $remainder,
-            $splitData
-        );
-    }
 
     private function forceIntegerValues(&$splitData)
     {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-325
| **What?**         | fix rule to divide remainder
| **Why?**          | The split rule was not working correctly.
| **How?**          | Add the comparison with empty and 0, because the empty() function considers 0 to be empty.
