### PR TITLE
Fixing deprecated "Passing null to parameter"

### DIFF
--- a/Block/Adminhtml/Recurrence/Subscriptions/Subscription.php
+++ b/Block/Adminhtml/Recurrence/Subscriptions/Subscription.php
@@ -110,8 +110,8 @@ class Subscription extends Template
 
     public function getFormattedName($name)
     {
-        if (preg_match('/[^a-zA-Z0-9 ]+/i', $name)) {
-            $name = preg_replace('/[^a-zA-Z0-9 ]+/i', '', $name);
+        if (preg_match('/[^a-zA-Z0-9 ]+/i', $name ?? '')) {
+            $name = preg_replace('/[^a-zA-Z0-9 ]+/i', '', $name ?? '');
         }
         return $name;
     }

--- a/Concrete/Magento2CoreSetup.php
+++ b/Concrete/Magento2CoreSetup.php
@@ -435,10 +435,10 @@ final class Magento2CoreSetup extends AbstractModuleCoreSetup
 
         $scope = ScopeInterface::SCOPE_WEBSITES;
         $storeId = self::getCurrentStoreId();
-        $selectedBrands = $storeConfig->getValue($section .  'cctypes', $scope, $storeId) ?? "";
+        $selectedBrands = $storeConfig->getValue($section .  'cctypes', $scope, $storeId) ?? '';
         $brands = array_merge([''], explode(
             ',',
-            $selectedBrands ?? ''
+            $selectedBrands
         ));
 
         $cardConfigs = [];

--- a/Concrete/Magento2CoreSetup.php
+++ b/Concrete/Magento2CoreSetup.php
@@ -438,17 +438,17 @@ final class Magento2CoreSetup extends AbstractModuleCoreSetup
         $selectedBrands = $storeConfig->getValue($section .  'cctypes', $scope, $storeId) ?? "";
         $brands = array_merge([''], explode(
             ',',
-            $selectedBrands
+            $selectedBrands ?? ''
         ));
 
         $cardConfigs = [];
         foreach ($brands as $brand) {
             $brand = "_" . strtolower($brand);
-            $brandMethod = str_replace('_', '', $brand);
+            $brandMethod = str_replace('_', '', $brand ?? '');
             $adapted = self::getBrandAdapter(strtoupper($brandMethod));
             if ($adapted !== false) {
                 $brand = "_" . strtolower($adapted);
-                $brandMethod = str_replace('_', '', $brand);
+                $brandMethod = str_replace('_', '', $brand ?? '');
             }
 
             if ($brandMethod == '') {

--- a/Concrete/Magento2DataService.php
+++ b/Concrete/Magento2DataService.php
@@ -21,7 +21,7 @@ class Magento2DataService extends AbstractDataService
         $orderId = $platformOrder->getPayment()->getParentId();
 
         $transactionAuth = $transactionRepository->getByTransactionId(
-            str_replace('-capture', '', $lastTransId),
+            str_replace('-capture', '', $lastTransId ?? ''),
             $paymentId,
             $orderId
         );
@@ -112,7 +112,7 @@ class Magento2DataService extends AbstractDataService
         $additionalInformation = $transactionAuth->getAdditionalInformation();
         foreach ($additionalInformation as $key => $value) {
             if ($value == $lastNsu) {
-                return str_replace('_acquirer_nsu', '', $key);
+                return str_replace('_acquirer_nsu', '', $key ?? '');
             }
         }
 

--- a/Concrete/Magento2PlatformOrderDecorator.php
+++ b/Concrete/Magento2PlatformOrderDecorator.php
@@ -104,7 +104,7 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
      */
     public function getState()
     {
-        $baseState = explode('_', $this->getPlatformOrder()->getState());
+        $baseState = explode('_', $this->getPlatformOrder()->getState() ?? '');
         $state = '';
         foreach ($baseState as $st) {
             $state .= ucfirst($st);
@@ -740,7 +740,7 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
         $paymentData = [];
 
         foreach ($payments as $payment) {
-            $handler = explode('_', $payment['method']);
+            $handler = explode('_', $payment['method'] ?? '');
             array_walk($handler, function (&$part) {
                 $part = ucfirst($part);
             });
@@ -857,8 +857,8 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
 
         $amount = $this->getGrandTotal() - $this->getBaseTaxAmount();
         $amount = number_format($amount, 2, '.', '');
-        $amount = str_replace('.', '', $amount);
-        $amount = str_replace(',', '', $amount);
+        $amount = str_replace('.', '', $amount ?? '');
+        $amount = str_replace(',', '', $amount ?? '');
 
         $newPaymentData->amount = $amount;
 
@@ -1032,7 +1032,7 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
         $amount = str_replace(
             ['.', ','],
             "",
-            $additionalInformation["cc_cc_amount"]
+            $additionalInformation["cc_cc_amount"] ?? ''
         );
         $newPaymentData->amount = $moneyService->floatToCents($amount / 100);
 
@@ -1055,7 +1055,7 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
         $amount = str_replace(
             ['.', ','],
             "",
-            $additionalInformation["cc_billet_amount"]
+            $additionalInformation["cc_billet_amount"] ?? ''
         );
 
         $newPaymentData->amount =
@@ -1177,7 +1177,7 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
         foreach ($addressAttributes as $attribute => $value) {
             $value = $value === null ? 1 : $value;
 
-            $street = explode("_", $value);
+            $street = explode("_", $value ?? '');
             if (count($street) > 1) {
                 $value = intval($street[1]) - 1;
             }

--- a/Concrete/Magento2PlatformPaymentMethodDecorator.php
+++ b/Concrete/Magento2PlatformPaymentMethodDecorator.php
@@ -23,7 +23,7 @@ class Magento2PlatformPaymentMethodDecorator implements PlatformPaymentMethodInt
     {
         $platformOrder = $platformOrder->getPlatformOrder();
         $payment = $platformOrder->getPayment();
-        $paymentMethod = explode('_', $payment->getMethod());
+        $paymentMethod = explode('_', $payment->getMethod() ?? '');
 
         if (!isset($paymentMethod[1])) {
             return $this->paymentMethod = $paymentMethod;

--- a/Controller/Adminhtml/Charges/Cancel.php
+++ b/Controller/Adminhtml/Charges/Cancel.php
@@ -31,7 +31,7 @@ class Cancel extends ChargeAction
 
         $this->setWebsiteConfiguration($params['chargeId']);
 
-        $amount = str_replace([',', '.'], "", $params['amount']);
+        $amount = str_replace([',', '.'], "", $params['amount'] ?? '');
         $chargeId = $params['chargeId'];
 
         $chargeService = new ChargeService();

--- a/Controller/Adminhtml/Charges/Capture.php
+++ b/Controller/Adminhtml/Charges/Capture.php
@@ -29,7 +29,7 @@ class Capture extends ChargeAction
         }
 
         $this->setWebsiteConfiguration($params['chargeId']);
-        $amount = str_replace([',', '.'], "", $params['amount']);
+        $amount = str_replace([',', '.'], "", $params['amount'] ?? '');
         $chargeId = $params['chargeId'];
 
         $chargeService = new ChargeService();

--- a/Controller/Adminhtml/Hub/Index.php
+++ b/Controller/Adminhtml/Hub/Index.php
@@ -85,7 +85,7 @@ class Index extends \Magento\Backend\App\Action
         }
 
         $url = $this->getUrl('adminhtml/system_config/edit/section/payment');
-        header('Location: ' . explode('?', $url)[0] . 'website/' . $websiteId);
+        header('Location: ' . explode('?', $url ?? '')[0] . 'website/' . $websiteId);
         exit;
     }
 

--- a/Controller/Adminhtml/Plans/SearchProduct.php
+++ b/Controller/Adminhtml/Plans/SearchProduct.php
@@ -112,8 +112,8 @@ class SearchProduct extends PlanAction
 
     public function getFormattedName($name)
     {
-        if (preg_match('/[^a-zA-Z0-9 ]+/i', $name)) {
-            $name = preg_replace('/[^a-zA-Z0-9 ]+/i', '', $name);
+        if (preg_match('/[^a-zA-Z0-9 ]+/i', $name ?? '')) {
+            $name = preg_replace('/[^a-zA-Z0-9 ]+/i', '', $name ?? '');
         }
         return $name;
     }

--- a/Controller/Customer/Remove.php
+++ b/Controller/Customer/Remove.php
@@ -69,7 +69,7 @@ class Remove extends Action
             $mask = '****.****.****.' . $card->getLastFourNumbers();
 
             $matchIds = [];
-            preg_match('/mp_core_\d*/', $idCard, $matchIds);
+            preg_match('/mp_core_\d*/', $idCard ?? '', $matchIds);
             $deleteService = $this->cardsRepository;
             $deleteMethod = 'deleteById';
 
@@ -133,14 +133,14 @@ class Remove extends Action
         $savedCardRepository = new SavedCardRepository();
 
         $matchIds = [];
-        preg_match('/mp_core_\d*/', $coreCardId, $matchIds);
+        preg_match('/mp_core_\d*/', $coreCardId ?? '', $matchIds);
 
 
         if (!isset($matchIds[0])) {
             throw $baseException;
         }
 
-        $savedCardId = preg_replace('/\D/', '', $matchIds[0]);
+        $savedCardId = preg_replace('/\D/', '', $matchIds[0] ?? '');
         $savedCard = $savedCardRepository->find($savedCardId);
         if ($savedCard === null) {
             throw $baseException;

--- a/Gateway/Transaction/Base/ResourceGateway/AbstractRequestDataProvider.php
+++ b/Gateway/Transaction/Base/ResourceGateway/AbstractRequestDataProvider.php
@@ -98,7 +98,7 @@ abstract class AbstractRequestDataProvider
      */
     public function getDocumentType()
     {
-        $identity = (int) preg_replace('/[^0-9]/','', $this->getDocumentNumber());
+        $identity = (int) preg_replace('/[^0-9]/','', $this->getDocumentNumber() ?? '');
         return (strlen($identity) === 14) ?
             \Pagarme\Pagarme\Model\Enum\DocumentTypeEnum::CNPJ :
             \Pagarme\Pagarme\Model\Enum\DocumentTypeEnum::CPF;
@@ -182,7 +182,7 @@ abstract class AbstractRequestDataProvider
      */
     public function getBillingAddressZipCode()
     {
-        return preg_replace('/[^0-9]/','', $this->getBillingAddressAttribute('postcode'));
+        return preg_replace('/[^0-9]/','', $this->getBillingAddressAttribute('postcode') ?? '');
     }
 
     /**
@@ -254,7 +254,7 @@ abstract class AbstractRequestDataProvider
      */
     public function getShippingAddressZipCode()
     {
-        return preg_replace('/[^0-9]/','', $this->getShippingAddressAttribute('postcode'));
+        return preg_replace('/[^0-9]/','', $this->getShippingAddressAttribute('postcode') ?? '');
     }
 
     /**
@@ -428,8 +428,8 @@ abstract class AbstractRequestDataProvider
      */
     protected function getBillingAddressAttribute($attribute)
     {
-        if (preg_match('/^street_/', $attribute)) {
-            $line = (int) str_replace('street_', '', $attribute);
+        if (preg_match('/^street_/', $attribute ?? '')) {
+            $line = (int) str_replace('street_', '', $attribute ?? '');
             return $this->getQuoteBillingAddress()->getStreetLine($line);
         }
         return $this->getQuoteBillingAddress()->getData($attribute);
@@ -441,8 +441,8 @@ abstract class AbstractRequestDataProvider
      */
     protected function getShippingAddressAttribute($attribute)
     {
-        if (preg_match('/^street_/', $attribute)) {
-            $line = (int) str_replace('street_', '', $attribute);
+        if (preg_match('/^street_/', $attribute ?? '')) {
+            $line = (int) str_replace('street_', '', $attribute ?? '');
             return $this->getQuoteShippingAddress()->getStreetLine($line);
         }
         return $this->getQuoteShippingAddress()->getData($attribute);

--- a/Helper/Adminhtml/CheckoutHelper.php
+++ b/Helper/Adminhtml/CheckoutHelper.php
@@ -27,7 +27,7 @@ class CheckoutHelper extends AbstractHelper
 
     public function getPaymentMethodConfig($code)
     {
-        $method = explode('_', $code);
+        $method = explode('_', $code ?? '');
         $moduleConfigurations = Magento2CoreSetup::getModuleConfiguration();
 
         $methods = [

--- a/Helper/BuildChargeAddtionalInformationHelper.php
+++ b/Helper/BuildChargeAddtionalInformationHelper.php
@@ -21,7 +21,7 @@ class BuildChargeAddtionalInformationHelper
         $methodName = str_replace(
             ['_', 'Pagarme'],
             '',
-            ucwords($paymentMethodPlatform, "_")
+            ucwords($paymentMethodPlatform ?? '', "_")
         );
 
         $methodName = "build{$methodName}";

--- a/Helper/ModuleHelper.php
+++ b/Helper/ModuleHelper.php
@@ -67,7 +67,7 @@ class ModuleHelper extends \Magento\Framework\App\Helper\AbstractHelper
         }
 
         if(($format ==  true) and (!is_null($this->taxVat))){
-             $this->taxVat = preg_replace("/[^0-9]/", "", $this->taxVat);
+             $this->taxVat = preg_replace("/[^0-9]/", "", $this->taxVat ?? '');
         }
         return $this->taxVat;
 

--- a/Helper/ModuleHelper.php
+++ b/Helper/ModuleHelper.php
@@ -67,7 +67,7 @@ class ModuleHelper extends \Magento\Framework\App\Helper\AbstractHelper
         }
 
         if(($format ==  true) and (!is_null($this->taxVat))){
-             $this->taxVat = preg_replace("/[^0-9]/", "", $this->taxVat ?? '');
+             $this->taxVat = preg_replace("/[^0-9]/", "", $this->taxVat);
         }
         return $this->taxVat;
 

--- a/Helper/ProductHelper.php
+++ b/Helper/ProductHelper.php
@@ -121,7 +121,7 @@ class ProductHelper
     public static function getStringBetween($title, $first_string, $second_string)
     {
         $str = json_encode($title);
-        $arr = explode($first_string, $str);
+        $arr = explode($first_string, $str ?? '');
         if (isset($arr[1])) {
             $arr = explode($second_string, $arr[1]);
             return $arr[0];

--- a/Model/Api/ProductsSubscription.php
+++ b/Model/Api/ProductsSubscription.php
@@ -226,7 +226,7 @@ class ProductsSubscription implements ProductSubscriptionApiInterface
             $repetition['recurrence_price'] = str_replace(
                 [',', '.'],
                 '',
-                $repetition['recurrence_price']
+                $repetition['recurrence_price'] ?? ''
             );
         }
 

--- a/Model/Api/Recipient.php
+++ b/Model/Api/Recipient.php
@@ -62,8 +62,8 @@ class Recipient implements RecipientInterface
 
     public function getFormattedForm(array $form): array
     {
-        $form['holder_document'] = preg_replace("/[^0-9]/", "", $form['holder_document']);
-        $form['document']  = preg_replace("/[^0-9]/", "", $form['document']);
+        $form['holder_document'] = preg_replace("/[^0-9]/", "", $form['holder_document'] ?? '');
+        $form['document']  = preg_replace("/[^0-9]/", "", $form['document'] ?? '');
         if (isset($form['type'])) {
             $form['holder_type'] = $form['type'];
         }

--- a/Model/CardsRepository.php
+++ b/Model/CardsRepository.php
@@ -103,10 +103,10 @@ class CardsRepository implements CardsRepositoryInterface
             $savedCardRepository = new SavedCardRepository();
 
             $matchIds = [];
-            preg_match('/mp_core_\d*/', $cardsId, $matchIds);
+            preg_match('/mp_core_\d*/', $cardsId ?? '', $matchIds);
 
             if (isset($matchIds[0])) {
-                $savedCardId = preg_replace('/\D/', '', $matchIds[0]);
+                $savedCardId = preg_replace('/\D/', '', $matchIds[0] ?? '');
                 $savedCard = $savedCardRepository->find($savedCardId);
                 if ($savedCard !== null) {
                     $objectManager = ObjectManager::getInstance();

--- a/Model/InstallmentsByBrandAndAmountManagement.php
+++ b/Model/InstallmentsByBrandAndAmountManagement.php
@@ -80,7 +80,7 @@ class InstallmentsByBrandAndAmountManagement
         $baseAmount = str_replace(
             [",", "."],
             "",
-            $baseAmount
+            $baseAmount ?? ''
         );
 
         $baseAmount = $moneyService->centsToFloat($baseAmount);

--- a/Model/Maintenance.php
+++ b/Model/Maintenance.php
@@ -15,11 +15,11 @@ class Maintenance
      */
     public function index($params)
     {
-        $baseParams = explode ('&', $params);
+        $baseParams = explode ('&', $params ?? '');
         $coreParams = [];
         foreach ($baseParams as $baseParam) {
 
-            $pair = explode('=' ,$baseParam);
+            $pair = explode('=' ,$baseParam ?? '');
             $key = array_shift($pair);
             $value = implode('=', $pair);
 

--- a/Model/Payment.php
+++ b/Model/Payment.php
@@ -158,7 +158,7 @@ class Payment
 
     public function formatPhone($phone)
     {
-        $phone = preg_replace("/[^0-9]/", "", $phone);
+        $phone = preg_replace("/[^0-9]/", "", $phone ?? '');
 
         return array('ddd' => $phone[0] . $phone[1], 'number' => substr($phone, 2));
     }

--- a/Plugin/Framework/Webapi/ServicePayloadConverterInterface.php
+++ b/Plugin/Framework/Webapi/ServicePayloadConverterInterface.php
@@ -76,7 +76,7 @@ class ServicePayloadConverterInterface
         try {
             $order = $this->_orderRepository->get($result[OrderInterface::ENTITY_ID]);
             if ($lastTransId = $order->getPayment()->getData(self::PAGARME_TRANSACTION_ID_FIELD)) {
-                $exploded = explode('-', $lastTransId);
+                $exploded = explode('-', $lastTransId ?? '');
                 $result['payment'][self::PAGARME_TRANSACTION_ID] = array_shift($exploded);
             }
         } catch (InputException | NoSuchEntityException $e) {

--- a/Ui/Component/Column/Actions.php
+++ b/Ui/Component/Column/Actions.php
@@ -80,7 +80,7 @@ class Actions extends Column
 
     protected function getUrlPagarme($type, $item, $path)
     {
-        $path = str_replace("*", $type, $path);
+        $path = str_replace("*", $type, $path ?? '');
 
         $url = $this->urlBuilder->getUrl($path, ['id' => $item['id']]);
         return $url;
@@ -88,7 +88,7 @@ class Actions extends Column
 
     protected function getType($namespace)
     {
-        preg_match('/pagarme_pagarme_(\w+)_listing/', $namespace, $type);
+        preg_match('/pagarme_pagarme_(\w+)_listing/', $namespace ?? '', $type);
         return $type[1];
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**           | https://mundipagg.atlassian.net/browse/PAOPN-355
| **What?**         | Fixed deprecated "Passing null to parameter" on functions in PHP8
| **Why?**          | To avoid exceptions ion this situations
| **How?**          | By adding `?? ''` to functions that expect strings