### PR TITLE
PAOPN-521: Compatibilization with magento 2.3.x

### DIFF
--- a/Block/Adminhtml/System/Config/Form/Field/MarketplaceMessage.php
+++ b/Block/Adminhtml/System/Config/Form/Field/MarketplaceMessage.php
@@ -27,15 +27,9 @@ class MarketplaceMessage extends Field
     {
         $html = "";
         if(!$this->moduleManager->isEnabled("Webkul_Marketplace")){
-            $html = __(<<<MSG
-                    <p class='message message-notification'>
-                        You need to activate the 
-                            <a href='https://store.webkul.com/magento2-multi-vendor-marketplace.html' target='_blank'>
-                                Webkul Marketplace
-                            </a>
-                        extension.
-                    </p>
-                MSG);    
+            $html = __("<p class='message message-notification'>You need to activate the " .
+                "<a href='https://store.webkul.com/magento2-multi-vendor-marketplace.html' target='_blank'>" .
+                "Webkul Marketplace</a> extension.</p>");
             }
         return $html;
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-521
| **What?**         | Compatibilization with magento 2.3.x.
| **Why?**          | Breaking setup:di:compile in magento 2.3.x versions
| **How?**          | Using usual php multiline string concatenation

