### PR TITLE
Fix Webapi\Exception __construct arguments

### DIFF
--- a/Gateway/Transaction/Base/Command/InitializeCommand.php
+++ b/Gateway/Transaction/Base/Command/InitializeCommand.php
@@ -166,7 +166,7 @@ class InitializeCommand implements CommandInterface
             throw new M2WebApiException(
                 new Phrase($e->getMessage()),
                 0,
-                $e->getCode()
+                M2WebApiException::HTTP_BAD_REQUEST
             );
         }
     }

--- a/Model/Api/ProductsPlan.php
+++ b/Model/Api/ProductsPlan.php
@@ -116,7 +116,7 @@ class ProductsPlan implements ProductPlanApiInterface
             throw new MagentoException(
                 __($exception->getMessage()),
                 0,
-                $exception->getCode()
+                MagentoException::HTTP_BAD_REQUEST
             );
         }
 
@@ -141,7 +141,7 @@ class ProductsPlan implements ProductPlanApiInterface
             throw new MagentoException(
                 __($exception->getMessage()),
                 0,
-                $exception->getCode()
+                MagentoException::HTTP_BAD_REQUEST
             );
         }
     }
@@ -168,7 +168,7 @@ class ProductsPlan implements ProductPlanApiInterface
             throw new MagentoException(
                 __($exception->getMessage()),
                 0,
-                $exception->getCode()
+                MagentoException::HTTP_BAD_REQUEST
             );
         }
 
@@ -194,7 +194,7 @@ class ProductsPlan implements ProductPlanApiInterface
             throw new MagentoException(
                 __($exception->getMessage()),
                 0,
-                $exception->getCode()
+                MagentoException::HTTP_BAD_REQUEST
             );
         }
     }
@@ -220,7 +220,7 @@ class ProductsPlan implements ProductPlanApiInterface
             throw new MagentoException(
                 __($exception->getMessage()),
                 0,
-                $exception->getCode()
+                MagentoException::HTTP_BAD_REQUEST
             );
         }
     }

--- a/Model/WebhookManagement.php
+++ b/Model/WebhookManagement.php
@@ -54,7 +54,7 @@ class WebhookManagement implements WebhookManagementInterface
             throw new M2WebApiException(
                 new Phrase($e->getMessage()),
                 0,
-                $e->getCode()
+                M2WebApiException::HTTP_BAD_REQUEST
             );
         }
     }

--- a/Observer/OrderCancelAfter.php
+++ b/Observer/OrderCancelAfter.php
@@ -68,7 +68,7 @@ class OrderCancelAfter implements ObserverInterface
             throw new M2WebApiException(
                 new Phrase($e->getMessage()),
                 0,
-                $e->getCode()
+                M2WebApiException::HTTP_BAD_REQUEST
             );
         }
     }


### PR DESCRIPTION
| Questions     | Answers 
| ------------- | -------------------------------------------------------
| **Issue**         | [https://github.com/pagarme/magento2/issues/237](https://github.com/pagarme/magento2/issues/237) 
| **What?**         | Updated the httpCode argument when throwing a new Magento\Framework\Webapi\Exception.
| **Why?**          | Magento\Framework\Webapi\Exception constructor throws an Exception if httpCode is not between 400 and 599
| **How?**          | Passing a httpCode, expected from Webapi\Exception, instead of 0, or any other number that comes from a caught exception. `} catch (\Exception $e) {` for example, does not guarantee that  $e->getCode() is going to return a number between 400 and 599.


<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### :package: Attachments (if appropriate)

Magento\Framework\Webapi\Exception constructor

![image](https://github.com/pagarme/magento2/assets/18008565/750d3d08-106f-44b3-98d7-3fc30ae8eb65)
#### :speech_balloon: Important guidelines

* Add pull request labels.
* Check base branch.
* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
