### PR TITLE
fix: adding due_at, bank and instructions information to be send to createOrder for billet payment method

### DIFF
--- a/Concrete/Magento2PlatformOrderDecorator.php
+++ b/Concrete/Magento2PlatformOrderDecorator.php
@@ -1140,6 +1140,19 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
         $newPaymentData = new \stdClass();
         $newPaymentData->amount =
             $this->moneyService->floatToCents($this->platformOrder->getGrandTotal());
+        $moduleConfiguration = MPSetup::getModuleConfiguration();
+        $newPaymentData->instructions = $moduleConfiguration->getBoletoInstructions();
+        $bankConfig = new Bank();
+        $bankNumber = $bankConfig->getBankNumber(MPSetup::getModuleConfiguration()->getBoletoBankCode());
+        if ($bankNumber) {
+            $newPaymentData->bank = $bankNumber;
+        }
+        $expirationDate = new \DateTime();
+        $days = MPSetup::getModuleConfiguration()->getBoletoDueDays();
+        if ($days) {
+            $expirationDate->modify("+{$days} day");
+        }
+        $newPaymentData->due_at = $expirationDate->format('c');
 
         $boletoDataIndex = BoletoPayment::getBaseCode();
         if (!isset($paymentData[$boletoDataIndex])) {

--- a/etc/adminhtml/system/transaction/billet.xml
+++ b/etc/adminhtml/system/transaction/billet.xml
@@ -36,6 +36,7 @@
                 <field id="active">1</field>
                 <field id="*/*/pagarme_pagarme_global/is_gateway_integration_type">1</field>
             </depends>
+            <validate>required-entry</validate>
 	    </field>
 	    <field id="instructions" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="textarea">
 	        <label>Payment instructions</label>


### PR DESCRIPTION


| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-608
| **What?**         | Adding due_at, bank and instructions information to be send to createOrder for billet payment method.
| **Why?**          | Send correct information to create billet order.
| **How?**          | Adding due_at, bank and instructions information to be send to createOrder for billet payment method.

