### PR TITLE
:bug: changes the function to check the size correctly

### DIFF
--- a/Observer/CustomerAddressSaveBefore.php
+++ b/Observer/CustomerAddressSaveBefore.php
@@ -62,7 +62,7 @@ class CustomerAddressSaveBefore implements ObserverInterface
             throw new InputException(__("Please check your address. Country is required."));
         }
 
-        if (empty($customerAddress->getName()) || strlen($customerAddress->getName()) > 65) {
+        if (empty($customerAddress->getName()) || mb_strlen($customerAddress->getName()) > 65) {
             throw new InputException(__("Please check your address. Name and firstname are required."));
         }
 


### PR DESCRIPTION
The strlen function returns the wrong string size if the string has any accented or cedilla characters, to calculate the size correctly you have to use the mb_strlen function

As shown in the image below

![image](https://github.com/pagarme/magento2/assets/7253572/d8568a3b-0a60-4fd2-b119-038cda82b819)




#### :speech_balloon: Important guidelines

* Add pull request labels.
* Check base branch.
* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
