### PR TITLE
feat: alternate pix and billet info

### DIFF
--- a/Block/Payment/Billet.php
+++ b/Block/Payment/Billet.php
@@ -67,6 +67,7 @@ class Billet extends Template
     public function getBilletUrl()
     {
         $billetHelper = new BilletHelper();
-        return $billetHelper->getBilletUrl($this->getPayment());
+        $pagarmeTransaction = $this->checkoutSession->getPixOrBilletTransaction();
+        return $billetHelper->getBilletUrl($this->getPayment(), $pagarmeTransaction);
     }
 }

--- a/Block/Payment/Pix.php
+++ b/Block/Payment/Pix.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class Billet
+ * Class Pix
  *
  * @author      Open Source Team
  * @copyright   2021 Pagar.me (https://pagar.me)
@@ -11,6 +11,8 @@
 
 namespace Pagarme\Pagarme\Block\Payment;
 
+use Exception;
+use Magento\Framework\Phrase;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Checkout\Model\Session as CheckoutSession;
@@ -94,7 +96,7 @@ class Pix extends Template
     }
 
     /**
-     * @return string
+     * @return Phrase
      */
     public function getSuccessMessage()
     {
@@ -103,11 +105,13 @@ class Pix extends Template
 
     /**
      * @return PixHelper
+     * @throws Exception
      */
     public function getPixInfo()
     {
+        $pagarmeTransaction = $this->checkoutSession->getPixOrBilletTransaction();
         if (empty($this->pixInfo)) {
-            $this->pixInfo = $this->pixHelper->getInfo($this->getPayment());
+            $this->pixInfo = $this->pixHelper->getInfo($this->getPayment(), $pagarmeTransaction);
         }
 
         return $this->pixInfo;

--- a/Gateway/Transaction/Base/Command/InitializeCommand.php
+++ b/Gateway/Transaction/Base/Command/InitializeCommand.php
@@ -169,8 +169,9 @@ class InitializeCommand implements CommandInterface
             if (!$isSubscription) {
                 $orderService = new OrderService();
                 $pagarmeOrder = current($orderService->createOrderAtPagarme($orderDecorator));
-                if (!is_null($pagarmeOrder->getPixOrBilletTransaction())) {
-                    $this->checkoutSession->setPixOrBilletTransaction($pagarmeOrder->getPixOrBilletTransaction());
+                $transaction = $pagarmeOrder->getPixOrBilletTransaction();
+                if (!is_null($transaction)) {
+                    $this->checkoutSession->setPixOrBilletTransaction($transaction);
                 }
             }
 

--- a/Gateway/Transaction/Base/Command/InitializeCommand.php
+++ b/Gateway/Transaction/Base/Command/InitializeCommand.php
@@ -12,6 +12,7 @@
 
 namespace Pagarme\Pagarme\Gateway\Transaction\Base\Command;
 
+use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Api\Data\OrderInterface;
@@ -28,25 +29,27 @@ use Pagarme\Pagarme\Model\Ui\CreditCard\ConfigProvider as CreditConfigProvider;
 use Pagarme\Pagarme\Model\Ui\TwoCreditCard\ConfigProvider as TwoCreditCardConfigProvider;
 use Magento\Framework\Phrase;
 use Magento\Framework\Webapi\Exception as M2WebApiException;
-use Pagarme\Pagarme\Helper\RecurrenceProductHelper;
-use Pagarme\Pagarme\Gateway\Transaction\Base\Config\Config;
 use Pagarme\Pagarme\Service\Transaction\ThreeDSService;
 
 class InitializeCommand implements CommandInterface
 {
 
-    protected $config;
     /**
      * @var ThreeDSService
      */
     protected $threeDSService;
+    /**
+     * @var CheckoutSession
+     */
+    protected $checkoutSession;
 
     public function __construct(
-        Config $config,
-        ThreeDSService $threeDSService
-    ){
-        $this->config = $config;
+        ThreeDSService  $threeDSService,
+        CheckoutSession $checkoutSession
+    )
+    {
         $this->threeDSService = $threeDSService;
+        $this->checkoutSession = $checkoutSession;
     }
 
     /**
@@ -110,10 +113,7 @@ class InitializeCommand implements CommandInterface
     /** @return AbstractPlatformOrderDecorator */
     private function doCoreDetour($payment)
     {
-        $order =  $payment->getOrder();
-        if($this->config->getAlwaysCreateOrder()){
-            $order->save();
-        }
+        $order = $payment->getOrder();
         $log = new OrderLogService();
 
         Magento2CoreSetup::bootstrap();
@@ -168,7 +168,10 @@ class InitializeCommand implements CommandInterface
 
             if (!$isSubscription) {
                 $orderService = new OrderService();
-                $orderService->createOrderAtPagarme($orderDecorator);
+                $pagarmeOrder = current($orderService->createOrderAtPagarme($orderDecorator));
+                if (!is_null($pagarmeOrder->getPixOrBilletTransaction())) {
+                    $this->checkoutSession->setPixOrBilletTransaction($pagarmeOrder->getPixOrBilletTransaction());
+                }
             }
 
             $orderDecorator->save();

--- a/Helper/Payment/Billet.php
+++ b/Helper/Payment/Billet.php
@@ -9,25 +9,25 @@
     use Pagarme\Core\Recurrence\Repositories\SubscriptionRepository;
 
     class Billet {
-        
-        public function getBilletUrl($info)
+
+        public function getBilletUrl($info, $transaction = null)
         {
             $method = $info->getMethod();
             if (strpos($method, "pagarme_billet") === false) {
                 return;
             }
-            
+
             Magento2CoreSetup::bootstrap();
-            $boletoUrl = $this->getBoletoLinkFromOrder($info);
+            $boletoUrl = $this->getBoletoLinkFromOrder($info, $transaction);
 
             if (!$boletoUrl) {
                 $boletoUrl = $this->getBoletoLinkFromSubscription($info);
             }
-    
+
             return $boletoUrl;
         }
 
-        private function getBoletoLinkFromOrder($info)
+        private function getBoletoLinkFromOrder($info, $transaction = null)
         {
             $lastTransId = $info->getLastTransId();
             $orderId = null;
@@ -35,8 +35,8 @@
                 $orderId = substr($lastTransId, 0, 19);
             }
 
-            if (!$orderId) {
-                return null;
+            if (!$orderId && !is_null($transaction)) {
+                return $transaction->getBoletoUrl();
             }
 
             $orderRepository = new OrderRepository();

--- a/Helper/Payment/Billet.php
+++ b/Helper/Payment/Billet.php
@@ -39,6 +39,10 @@
                 return $transaction->getBoletoUrl();
             }
 
+            if (!$orderId) {
+                return null;
+            }
+
             $orderRepository = new OrderRepository();
             $order = $orderRepository->findByPagarmeId(new OrderId($orderId));
 

--- a/Helper/Payment/Pix.php
+++ b/Helper/Payment/Pix.php
@@ -2,6 +2,7 @@
 
 namespace Pagarme\Pagarme\Helper\Payment;
 
+use Exception;
 use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
 use Pagarme\Core\Kernel\ValueObjects\Id\OrderId;
 use Pagarme\Core\Payment\Services\OrderService;
@@ -13,8 +14,9 @@ class Pix
 
     /**
      * @return $this
+     * @throws Exception
      */
-    public function getInfo($info)
+    public function getInfo($info, $transaction = null)
     {
         $orderId = null;
         $method = $info->getMethod();
@@ -25,6 +27,12 @@ class Pix
         $lastTransId = $info->getLastTransId();
         if ($lastTransId) {
             $orderId = substr($lastTransId, 0, 19);
+        }
+
+        if (!$orderId && !is_null($transaction)) {
+            $this->setQrCode($transaction->getPostData()->qr_code);
+            $this->setQrCodeUrl($transaction->getPostData()->qr_code_url);
+            return $this;
         }
 
         Magento2CoreSetup::bootstrap();


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **stg**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [x] Adição de funcionalidade
- [ ] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Adicionado método alternativo para buscar as informações de QrCode de Pix ou URL de Boleto. Ver tarefa: https://mundipagg.atlassian.net/browse/PAOPN-663


### Cenários testados
Defini `null` no `$orderId` para testar o retorno da nova função quando a original falhar. Retorno está conforme esperado. Testado pedidos com Pix, Boleto e Cartão de Crédito. Todos ok!