### PR TITLE
Paopn 679/fix billet and credit multimeans

### DIFF
--- a/Concrete/Magento2PlatformOrderDecorator.php
+++ b/Concrete/Magento2PlatformOrderDecorator.php
@@ -1135,11 +1135,10 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
         $payment
     ) {
         $newPaymentData = new stdClass();
-        $amount = str_replace(
-            ['.', ','],
-            ['','.'],
-            $additionalInformation["cc_billet_amount"] ?? $this->platformOrder->getGrandTotal()
-        );
+        $amount = $this->platformOrder->getGrandTotal();
+        if (isset($additionalInformation["cc_billet_amount"])) {
+            $amount = $this->moneyService->removeSeparators($additionalInformation["cc_billet_amount"]) / 100;
+        }
         $newPaymentData->amount =
             $this->moneyService->floatToCents($amount);
         $moduleConfiguration = MPSetup::getModuleConfiguration();

--- a/Concrete/Magento2PlatformOrderDecorator.php
+++ b/Concrete/Magento2PlatformOrderDecorator.php
@@ -1122,30 +1122,11 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
 
         $paymentData[$creditCardDataIndex][] = $newPaymentData;
 
-        //boleto
-
-        $newPaymentData = new stdClass();
-
-        $amount = str_replace(
-            ['.', ','],
-            "",
-            $additionalInformation["cc_billet_amount"] ?? ''
+        $this->extractPaymentDataFromPagarmeBillet(
+            $additionalInformation,
+            $paymentData,
+            $payment
         );
-
-        $newPaymentData->amount =
-            $this->moneyService->floatToCents($amount / 100);
-
-        $boletoDataIndex = BoletoPayment::getBaseCode();
-        if (!isset($paymentData[$boletoDataIndex])) {
-            $paymentData[$boletoDataIndex] = [];
-        }
-
-        $newPaymentData->customer = $this->extractMultibuyerData(
-            'billet',
-            $additionalInformation
-        );
-
-        $paymentData[$boletoDataIndex][] = $newPaymentData;
     }
 
     private function extractPaymentDataFromPagarmeBillet(
@@ -1154,17 +1135,22 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
         $payment
     ) {
         $newPaymentData = new stdClass();
+        $amount = str_replace(
+            ['.', ','],
+            ['','.'],
+            $additionalInformation["cc_billet_amount"] ?? $this->platformOrder->getGrandTotal()
+        );
         $newPaymentData->amount =
-            $this->moneyService->floatToCents($this->platformOrder->getGrandTotal());
+            $this->moneyService->floatToCents($amount);
         $moduleConfiguration = MPSetup::getModuleConfiguration();
         $newPaymentData->instructions = $moduleConfiguration->getBoletoInstructions();
         $bankConfig = new Bank();
-        $bankNumber = $bankConfig->getBankNumber(MPSetup::getModuleConfiguration()->getBoletoBankCode());
+        $bankNumber = $bankConfig->getBankNumber($moduleConfiguration->getBoletoBankCode());
         if ($bankNumber) {
             $newPaymentData->bank = $bankNumber;
         }
         $expirationDate = new \DateTime();
-        $days = MPSetup::getModuleConfiguration()->getBoletoDueDays();
+        $days = $moduleConfiguration->getBoletoDueDays();
         if ($days) {
             $expirationDate->modify("+{$days} day");
         }


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **stg**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [x] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Removido códigos duplicados de boleto, fazendo a chamada da função `extractPaymentDataFromPagarmeBillet()`, que foi alterada para pegar o valor do multimeio quando disponível, ou do `grandTotal()` quando não houver o amount do multimeio.


### Cenários testados
Efetuado diversas compras com multimeio "Boleto e Cartão" e apenas "Boleto". Fiz testes com valores baixos e altos (acima de mil reais) e quebrados (incluindo centavos). Compras verificadas no admin do Magento e na Dash da Pagar.me