### PR TITLE
fix: sintax error for di compile

### DIFF
--- a/Model/Notifications.php
+++ b/Model/Notifications.php
@@ -212,7 +212,7 @@ class Notifications extends Message
             CoreAccount::DOMAIN_INCORRECT => sprintf(
                 __('The registered <b>domain</b> is different from the URL of your website. Please correct the '
                 . 'domain configured on the <b>%s</b> to be able to process payment in your store.'),
-                $this->buildDashLink($linkLabel, $linkAccount),
+                $this->buildDashLink($linkLabel, $linkAccount)
             ),
             CoreAccount::WEBHOOK_INCORRECT => sprintf(
                 __('The URL for receiving <b>webhooks</b> registered in Pagar.me Dash is different from the URL of '


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://mundipagg.atlassian.net/browse/PAOPN-682
| **What?**         | Fix sintax error for setup:di:compile on magento 2.3.0
| **Why?**          | Be compatible with magento 2.3.0
| **How?**          | Remove sintax error
| **Issue**           | https://github.com/pagarme/magento2/issues/309

