### PR TITLE
fix: recipient document maxLength

### DIFF
--- a/Controller/Adminhtml/Recipients/Create.php
+++ b/Controller/Adminhtml/Recipients/Create.php
@@ -40,7 +40,7 @@ class Create extends RecipientAction
 
         $resultPage = $this->resultPageFactory->create();
 
-        $title = $recipientId ? __('Edit Recipient') : __('Create Recipient');
+        $title = $recipientId ? __('Recipient') : __('Create Recipient');
 
         $resultPage->getConfig()->getTitle()->prepend($title);
 

--- a/i18n/pt_BR.csv
+++ b/i18n/pt_BR.csv
@@ -496,6 +496,7 @@
 "Weekly","Semanalmente"
 "Monthly","Mensalmente"
 "Create Recipient","Criar Recebedor"
+"Recipient","Recebedor"
 "Save","Salvar"
 "Back","Voltar"
 "Can't create recipient. Please review the information and try again.","Não foi possível criar o recebedor. Por favor revise os dados e tente novamente."

--- a/view/adminhtml/templates/marketplace/recipients/create.phtml
+++ b/view/adminhtml/templates/marketplace/recipients/create.phtml
@@ -157,7 +157,7 @@ $editRecipient = $block->getEditRecipient(); ?>
                                     <div class="admin__field-control">
                                         <input type="text" class="recipient-form-inputs"
                                                name="form[register_information][document]" id="document"
-                                               placeholder="000.000.000-00" maxlength="14"
+                                               placeholder="000.000.000-00"
                                                data-document-number-for="seller"
                                                data-document-mask data-toggle-required>
                                     </div>
@@ -587,7 +587,7 @@ $editRecipient = $block->getEditRecipient(); ?>
                                         <input type="text" class="recipient-form-inputs"
                                                name="form[register_information][managing_partners][0][document]"
                                                id="recipient-partner-0-document" placeholder="000.000.000-00"
-                                               maxlength="14" data-document-mask data-toggle-required>
+                                               data-document-mask data-toggle-required>
                                     </div>
                                 </div>
 
@@ -842,7 +842,7 @@ $editRecipient = $block->getEditRecipient(); ?>
                                     <div class="admin__field-control">
                                         <input type="text" class="recipient-form-inputs"
                                                name="form[holder_document]" id="holder-document"
-                                               placeholder="000.000.000-00" maxlength="14" readonly data-document-mask
+                                               placeholder="000.000.000-00" readonly data-document-mask
                                                data-toggle-required>
                                     </div>
                                 </div>

--- a/view/adminhtml/web/js/recipients.js
+++ b/view/adminhtml/web/js/recipients.js
@@ -147,20 +147,14 @@ require([
     });
 
     function changeDocumentFieldsByType(documentType) {
-        const config = {
-            'mask': documentType === 'corporation' ? cnpjMask : cpfMask,
-            'maxLength': documentType === 'corporation' ? cnpjMax : cpfMax
-        };
+        const documentMask = documentType === 'corporation' ? cnpjMask : cpfMask;
 
         $(fieldId['holderDocumentType'])
             .val(documentTypeCorporationToCompany(documentType));
 
         $('#document, #holder-document')
-            .attr({
-                'placeholder': config.mask,
-                'maxLength': config.maxLength
-            })
-            .mask(config.mask);
+            .attr('placeholder', documentMask)
+            .mask(documentMask);
     }
 
     function documentTypeCorporationToCompany(documentType) {


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [x] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
* Corrigido alternação de maxLength no campo do número de documento quando `document_type` é `corporation`.
* Corrigido título da página de recebedores quando entra para visualizar.

### Cenários testados
Não foi possível efetuar testes, pois o erro não ocorre no meu ambiente local. Mas o recurso de `maxLengh` não é necessário já que o campo possui máscara, o que já limita o seu tamanho.