### PR TITLE
Paopn 755/feat add account id to gpay

### DIFF
--- a/etc/adminhtml/system/transaction/googlepay.xml
+++ b/etc/adminhtml/system/transaction/googlepay.xml
@@ -10,25 +10,40 @@
         <field id="title" type="text" sortOrder="20" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
             <label>Payment label</label>
             <config_path>payment/pagarme_googlepay/title</config_path>
+            <depends>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="pagarme_account_id" type="text" sortOrder="30" showInWebsite="1" showInStore="1" showInDefault="1" translate="label, comment">
             <label>Pagar.me account ID</label>
             <comment><![CDATA[Consult the <a target='_blank' href='https://id.pagar.me/signin'>Dashboard</a> at: <i>Settings > Keys > Account ID</i>]]></comment>
             <config_path>pagarme_pagarme/hub/account_id</config_path>
+            <depends>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="merchant_id" type="text" sortOrder="40" showInWebsite="1" showInStore="1" showInDefault="1" translate="label, comment">
             <label>MerchantId Google Pay</label>
             <comment><![CDATA[Google Pay identifier required to create successful orders. Find out how to request <a target='_blank' href='https://pay.google.com/business/console/?hl=pt-br'>here</a>.]]></comment>
             <config_path>payment/pagarme_googlepay/merchant_id</config_path>
+            <depends>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="merchant_name" type="text" sortOrder="50" showInWebsite="1" showInStore="1" showInDefault="1" translate="label, tooltip">
             <label>Store name on Google Pay</label>
             <config_path>payment/pagarme_googlepay/merchant_name</config_path>
             <tooltip>Name of your store that will be displayed to the customer while purchasing through Google Pay.</tooltip>
+            <depends>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="sort_order" type="text" sortOrder="60" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
             <label>Payment method order</label>
             <config_path>payment/pagarme_googlepay/sort_order</config_path>
+            <depends>
+                <field id="active">1</field>
+            </depends>
         </field>
     </group>
 </include>

--- a/etc/adminhtml/system/transaction/googlepay.xml
+++ b/etc/adminhtml/system/transaction/googlepay.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" ?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
-	
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="pagarme_googlepay" showInWebsite="1" showInStore="1" showInDefault="1" translate="label"  sortOrder="50">
         <label>Google Pay</label>
         <field id="active" type="select" sortOrder="10" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
@@ -12,19 +11,24 @@
             <label>Payment label</label>
             <config_path>payment/pagarme_googlepay/title</config_path>
         </field>
-        <field id="merchant_id" type="text" sortOrder="30" showInWebsite="1" showInStore="1" showInDefault="1" translate="label, comment">
+        <field id="pagarme_account_id" type="text" sortOrder="30" showInWebsite="1" showInStore="1" showInDefault="1" translate="label, comment">
+            <label>Pagar.me account ID</label>
+            <comment><![CDATA[Consult the <a target='_blank' href='https://id.pagar.me/signin'>Dashboard</a> at: <i>Settings > Keys > Account ID</i>]]></comment>
+            <config_path>pagarme_pagarme/hub/account_id</config_path>
+        </field>
+        <field id="merchant_id" type="text" sortOrder="40" showInWebsite="1" showInStore="1" showInDefault="1" translate="label, comment">
             <label>MerchantId Google Pay</label>
-            <comment><![CDATA[Google Pay identifier required to create successful orders, find out how to request <a target='_blank' href='https://pay.google.com/business/console/?hl=pt-br'>here</a>.]]></comment>
+            <comment><![CDATA[Google Pay identifier required to create successful orders. Find out how to request <a target='_blank' href='https://pay.google.com/business/console/?hl=pt-br'>here</a>.]]></comment>
             <config_path>payment/pagarme_googlepay/merchant_id</config_path>
         </field>
-        <field id="merchant_name" type="text" sortOrder="40" showInWebsite="1" showInStore="1" showInDefault="1" translate="label, tooltip">
+        <field id="merchant_name" type="text" sortOrder="50" showInWebsite="1" showInStore="1" showInDefault="1" translate="label, tooltip">
             <label>Store name on Google Pay</label>
             <config_path>payment/pagarme_googlepay/merchant_name</config_path>
             <tooltip>Name of your store that will be displayed to the customer while purchasing through Google Pay.</tooltip>
         </field>
-        <field id="sort_order" type="text" sortOrder="50" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
+        <field id="sort_order" type="text" sortOrder="60" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
             <label>Payment method order</label>
             <config_path>payment/pagarme_googlepay/sort_order</config_path>
         </field>
     </group>
-</config>
+</include>

--- a/i18n/pt_BR.csv
+++ b/i18n/pt_BR.csv
@@ -608,6 +608,8 @@
 "Recipient not founded.","Recebedor não encontrado."
 "Failed to generate the security validation link.","Falha ao gerar o link de validação de segurança."
 "Something went wrong, please try again later.","Algo deu errado, por favor tente novamente mais tarde."
+"Pagar.me account ID", "ID da conta Pagar.me"
+"Consult the <a target='_blank' href='https://id.pagar.me/signin'>Dashboard</a> at: <i>Settings > Keys > Account ID</i>", "Consulte na <a target='_blank' href='https://id.pagar.me/signin'>Dashboard</a> em: <i>Configurações > Chaves > ID da Conta</i>"
 "Google Pay identifier required to create successful orders, find out how to request <a target='_blank' href='https://pay.google.com/business/console/?hl=pt-br'>here</a>.", "Identificador do Google Pay necessário para criação de pedidos com sucesso, saiba como solicitar <a target='_blank' href='https://pay.google.com/business/console/?hl=pt-br'>aqui</a>."
 "MerchantId Google Pay", "MerchantId Google Pay"
 "Store name on Google Pay", "Nome da loja no Google Pay"

--- a/i18n/pt_BR.csv
+++ b/i18n/pt_BR.csv
@@ -610,7 +610,7 @@
 "Something went wrong, please try again later.","Algo deu errado, por favor tente novamente mais tarde."
 "Pagar.me account ID", "ID da conta Pagar.me"
 "Consult the <a target='_blank' href='https://id.pagar.me/signin'>Dashboard</a> at: <i>Settings > Keys > Account ID</i>", "Consulte na <a target='_blank' href='https://id.pagar.me/signin'>Dashboard</a> em: <i>Configurações > Chaves > ID da Conta</i>"
-"Google Pay identifier required to create successful orders, find out how to request <a target='_blank' href='https://pay.google.com/business/console/?hl=pt-br'>here</a>.", "Identificador do Google Pay necessário para criação de pedidos com sucesso, saiba como solicitar <a target='_blank' href='https://pay.google.com/business/console/?hl=pt-br'>aqui</a>."
+"Google Pay identifier required to create successful orders. Find out how to request <a target='_blank' href='https://pay.google.com/business/console/?hl=pt-br'>here</a>.", "Identificador do Google Pay necessário para criação de pedidos com sucesso. Saiba como solicitar <a target='_blank' href='https://pay.google.com/business/console/?hl=pt-br'>aqui</a>."
 "MerchantId Google Pay", "MerchantId Google Pay"
 "Store name on Google Pay", "Nome da loja no Google Pay"
 "Name of your store that will be displayed to the customer while purchasing through Google Pay.", "Nome da sua loja que será exibida ao cliente durante a compra pelo Google Pay."


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **develop**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [x] Adição de funcionalidade
- [ ] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
* Adicionado campo nas opções de Google Pay para inserção do Account ID da Pagar.me quando a loja não foi recentemente integrada.
* Corrigido os campos das configurações de Google Pay para exibi-los apenas quando o Google Pay estiver ativo

### Cenários testados
* Campo adicionado salvando account id no mesmo registro da integração do Hub.