### PR TITLE
handle empty card brands configuration

### DIFF
--- a/Gateway/Transaction/GooglePay/Config/Config.php
+++ b/Gateway/Transaction/GooglePay/Config/Config.php
@@ -56,7 +56,7 @@ class Config extends AbstractConfig implements ConfigInterface
     public function getCardBrands()
     {
         $brandsAllowed = [];
-        $creditCardBrandsSelected = explode(',', $this->getConfig(static::CARD_BRANDS));
+        $creditCardBrandsSelected = explode(',', $this->getConfig(static::CARD_BRANDS) ?? '');
         foreach ($creditCardBrandsSelected as $brand) {
             if (in_array(strtoupper($brand), static::GOOGLE_POSSIBLE_BRANDS)) {
                 $brandsAllowed[] = strtoupper($brand);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | #356 
| **What?**         | Handle empty card brand configuration.
| **Why?**          | So the checkout page can work as expected with credit card payment disabled.
| **How?**          | Handling the null return from the database, when there is no credit card configured.

