### PR TITLE
fix: queue commands running without Pagar.me integration

### DIFF
--- a/Api/SubscriptionApiInterface.php
+++ b/Api/SubscriptionApiInterface.php
@@ -12,14 +12,6 @@ interface SubscriptionApiInterface
     public function list();
 
     /**
-     * List product subscription
-     *
-     * @param string $customerId
-     * @return \Pagarme\Core\Recurrence\Interfaces\SubscriptionInterface[]
-     */
-    public function listByCustomerId($customerId);
-
-    /**
      * Cancel subscription
      *
      * @param int $id

--- a/Model/Api/Subscription.php
+++ b/Model/Api/Subscription.php
@@ -2,42 +2,25 @@
 
 namespace Pagarme\Pagarme\Model\Api;
 
-use Magento\Framework\Webapi\Rest\Request;
-use Pagarme\Core\Kernel\Services\LocalizationService;
-use Pagarme\Core\Kernel\Services\MoneyService;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\State;
 use Pagarme\Core\Recurrence\Services\SubscriptionService;
 use Pagarme\Pagarme\Api\SubscriptionApiInterface;
 use Pagarme\Pagarme\Concrete\Magento2CoreSetup;
 
 class Subscription implements SubscriptionApiInterface
 {
-
-    /**
-     * @var Request
-     */
-    protected $request;
     /**
      * @var SubscriptionService
      */
     protected $subscriptionService;
 
-    /**
-     * @var LocalizationService
-     */
-    protected $i18n;
-
-    /**
-     * @var MoneyService
-     */
-    protected $moneyService;
-
-    public function __construct(Request $request)
+    public function __construct(State $state)
     {
-        $this->request = $request;
-        Magento2CoreSetup::bootstrap();
-        $this->i18n = new LocalizationService();
-        $this->moneyService = new MoneyService();
-        $this->subscriptionService = new SubscriptionService();
+        if ($state->getAreaCode() === Area::AREA_WEBAPI_REST) {
+            Magento2CoreSetup::bootstrap();
+            $this->subscriptionService = new SubscriptionService();
+        }
     }
 
     /**
@@ -68,16 +51,5 @@ class Subscription implements SubscriptionApiInterface
                 "message" => $exception->getMessage()
             ];
         }
-    }
-
-    /**
-     * List product subscription
-     *
-     * @param string $customerId
-     * @return \Pagarme\Core\Recurrence\Interfaces\SubscriptionInterface[]
-     */
-    public function listByCustomerId($customerId)
-    {
-        // TODO: Implement listByCustomerId() method.
     }
 }

--- a/Test/Unit/Model/Api/SubscriptionTest.php
+++ b/Test/Unit/Model/Api/SubscriptionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Pagarme\Pagarme\Test\Unit\Model\Api;
+
+use Exception;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\State;
+use Mockery;
+use Pagarme\Pagarme\Test\Unit\BaseTest;
+use Pagarme\Pagarme\Model\Api\Subscription;
+use Pagarme\Core\Recurrence\Aggregates\Subscription as SubscriptionModel;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class SubscriptionTest extends BaseTest
+{
+    public function testListShouldReturnAllSubscriptions()
+    {
+        $subscriptionServiceMock = Mockery::mock('overload:Pagarme\Core\Recurrence\Services\SubscriptionService');
+        $magento2CoreSetupMock = Mockery::mock('alias:Pagarme\Pagarme\Concrete\Magento2CoreSetup');
+        $magento2CoreSetupMock->shouldReceive('bootstrap')
+            ->andReturnSelf();
+
+        $subscriptionModel = new SubscriptionModel();
+        $subscriptionModel->setId("123");
+        $subscriptionModels = [$subscriptionModel];
+
+        $subscriptionServiceMock->shouldReceive('listAll')
+            ->andReturn($subscriptionModels);
+
+        $stateMock = Mockery::mock(State::class);
+        $stateMock->shouldReceive('getAreaCode')
+            ->andReturn(Area::AREA_WEBAPI_REST);
+        
+        $subscription = new Subscription($stateMock);
+        
+        $expectedResult = json_decode(json_encode($subscriptionModels), true);
+
+        $result = $subscription->list();
+
+        $this->assertSame($result, $expectedResult);
+    }
+
+    public function testCancelShouldReturnSucessArray()
+    {
+        $subscriptionServiceMock = Mockery::mock('overload:Pagarme\Core\Recurrence\Services\SubscriptionService');
+        $magento2CoreSetupMock = Mockery::mock('alias:Pagarme\Pagarme\Concrete\Magento2CoreSetup');
+        $magento2CoreSetupMock->shouldReceive('bootstrap')
+            ->andReturnSelf();
+
+        $expectedResult = [
+            "message" => 'Subscription canceled with success!',
+            "code" => 200
+        ];
+        $subscriptionServiceMock->shouldReceive('cancel')
+            ->andReturn($expectedResult);
+
+        $stateMock = Mockery::mock(State::class);
+        $stateMock->shouldReceive('getAreaCode')
+            ->andReturn(Area::AREA_WEBAPI_REST);
+        
+        $subscription = new Subscription($stateMock);
+
+        $id = '123';
+        $result = $subscription->cancel($id);
+
+        $this->assertSame($result, $expectedResult);
+    }
+
+    public function testCancelShouldReturnErrorArray()
+    {
+        $subscriptionServiceMock = Mockery::mock('overload:Pagarme\Core\Recurrence\Services\SubscriptionService');
+        $magento2CoreSetupMock = Mockery::mock('alias:Pagarme\Pagarme\Concrete\Magento2CoreSetup');
+        $magento2CoreSetupMock->shouldReceive('bootstrap')
+            ->andReturnSelf();
+
+        $expectedResult = [
+            "code" => 400,
+            "message" => 'Error while canceling subscription',
+        ];
+
+        $exception = new Exception('Error while canceling subscription', 400);
+        $subscriptionServiceMock->shouldReceive('cancel')
+            ->andThrow($exception);
+
+        $stateMock = Mockery::mock(State::class);
+        $stateMock->shouldReceive('getAreaCode')
+            ->andReturn(Area::AREA_WEBAPI_REST);
+        
+        $subscription = new Subscription($stateMock);
+
+        $id = '123';
+        $result = $subscription->cancel($id);
+
+        $this->assertSame($result, $expectedResult);
+    }
+}


### PR DESCRIPTION
![Git Merge](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExanI1NnE0OHZuajZnbm0wMzF6NTlxdGxxYXA1M2x3NnhkNGp5bHc2cSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/EhROYVkODuF2m1zd64/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **stg**.

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [ ] Refatoração
- [ ] Adição de funcionalidade
- [x] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Foi alterado para que só crie o SubscriptionService quando estiver apenas no escopo de WebAPi Rest, fazendo com que os comando queue:consumers:start funcione sem estar integrado no Hub.


### Cenários testados
Rodado o comando abaixo com sucesso:
`bin/magento queue:consumers:start async.operations.all -vvv`
![2024-10-26_15-32](https://github.com/user-attachments/assets/18da2329-add7-43fe-b4e7-e7d4d2e90c44)