### PR TITLE
refactor: createOrderAtPagarme returns object

### DIFF
--- a/Gateway/Transaction/Base/Command/InitializeCommand.php
+++ b/Gateway/Transaction/Base/Command/InitializeCommand.php
@@ -168,7 +168,7 @@ class InitializeCommand implements CommandInterface
 
             if (!$isSubscription) {
                 $orderService = new OrderService();
-                $pagarmeOrder = current($orderService->createOrderAtPagarme($orderDecorator));
+                $pagarmeOrder = $orderService->createOrderAtPagarme($orderDecorator);
                 $transaction = $pagarmeOrder->getPixOrBilletTransaction();
                 if (!is_null($transaction)) {
                     $this->checkoutSession->setPixOrBilletTransaction($transaction);


### PR DESCRIPTION
![Paying](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExMTFmY3dodHBiMmhwZTE4dmR0d3kwaTBsN21rN2E4Y2d0OTZiazVjaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/jsMyQhL2MAmRO7MypH/giphy.gif)

> [!IMPORTANT]
> Certifique-se de criar o PR para a branch **stg**.

### Tarefa [ECPJ-54](https://allstone.atlassian.net/browse/ECPJ-54)

### Qual o tipo de PR é esse? (marque todos os aplicáveis)
- [x] Refatoração
- [ ] Adição de funcionalidade
- [ ] Correção de bug
- [ ] Otimização
- [ ] Atualização de documentação

### Descrição
Método `createOrderAtPagarme` foi modificado no [Core](https://github.com/pagarme/ecommerce-module-core/pull/177) e agora retorna um objeto, no lugar de um array contendo apenas um objeto. Essa função é utilizada no Magento uma única vez. Este PR refatora para tratar a resposta como objeto.

### Testes
Testado fluxos de compras com Cartão de Crédito, Pix e Boleto

[ECPJ-54]: https://allstone.atlassian.net/browse/ECPJ-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ