### PR TITLE
fix: prevent undefined array key warnings in HubIntegrationObserver

### DIFF
--- a/Observer/HubIntegrationObserver.php
+++ b/Observer/HubIntegrationObserver.php
@@ -30,11 +30,16 @@ class HubIntegrationObserver implements ObserverInterface
     {
         $configData = $observer->getData('event')->getData('configData');
 
-        if ($configData[ScopeInterface::SCOPE_WEBSITE] === null) {
+        if (empty($configData[ScopeInterface::SCOPE_WEBSITE])) {
             return;
         }
 
-        $pagarmeGlobalFields = $configData['groups']['pagarme_pagarme']['groups']['pagarme_pagarme_global']['fields'];
+        $pagarmeGlobalFields = [];
+
+        if (isset($configData['groups']['pagarme_pagarme']['groups']['pagarme_pagarme_global']['fields'])) {
+            $pagarmeGlobalFields = $configData['groups']['pagarme_pagarme']['groups']['pagarme_pagarme_global']['fields'];
+        }
+
         $integrationUseDefault = 0;
 
         if (array_key_exists('hub_integration', $pagarmeGlobalFields)) {


### PR DESCRIPTION
Problem:

When the Hub authorization flow redirected back to the admin panel with query params like &install_token, the HubIntegrationObserver::execute() method was throwing PHP warnings:

Warning: Undefined array key "website" in HubIntegrationObserver.php on line 33 
Warning: Undefined array key "fields" in HubIntegrationObserver.php on line 37.

These warnings were being caught and displayed as exceptions by Magento\Framework\Webapi\Exception, breaking the Hub integration.

Root Cause:

Two unguarded array accesses in execute():

$configData[ScopeInterface::SCOPE_WEBSITE] was accessed with === null which only handles the case where the key exists but is null — if the key is absent PHP throws a warning. $configData['groups']['pagarme_pagarme']['groups']['pagarme_pagarme_global']['fields'] was accessed directly without checking nested key existence.

Fix:

Replaced the === null check with empty(), which safely handles both absent keys and null/empty values without triggering warnings. Added an isset() guard before accessing the nested fields key, initializing $pagarmeGlobalFields as an empty array as fallback.