### PR TITLE
fix: prevent undefined array key warnings in Hub integration

### DIFF
--- a/Controller/Adminhtml/Hub/Index.php
+++ b/Controller/Adminhtml/Hub/Index.php
@@ -73,7 +73,7 @@ class Index extends Action
             try {
                 $hubIntegrationService = new HubIntegrationService();
                 $hubIntegrationService->endHubIntegration(
-                    $params['&install_token'],
+                    $params['install_token'] ?? null,
                     $params['authorization_code'],
                     $this->getCallbackUrl($websiteId),
                     $this->getWebHookkUrl()

--- a/Observer/HubIntegrationObserver.php
+++ b/Observer/HubIntegrationObserver.php
@@ -30,11 +30,16 @@ class HubIntegrationObserver implements ObserverInterface
     {
         $configData = $observer->getData('event')->getData('configData');
 
-        if ($configData[ScopeInterface::SCOPE_WEBSITE] === null) {
+        if (empty($configData[ScopeInterface::SCOPE_WEBSITE])) {
             return;
         }
 
-        $pagarmeGlobalFields = $configData['groups']['pagarme_pagarme']['groups']['pagarme_pagarme_global']['fields'];
+        $pagarmeGlobalFields = [];
+
+        if (isset($configData['groups']['pagarme_pagarme']['groups']['pagarme_pagarme_global']['fields'])) {
+            $pagarmeGlobalFields = $configData['groups']['pagarme_pagarme']['groups']['pagarme_pagarme_global']['fields'];
+        }
+
         $integrationUseDefault = 0;
 
         if (array_key_exists('hub_integration', $pagarmeGlobalFields)) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | N/A
| **What?**         | Fix undefined array key warnings in Hub integration flow
| **Why?**          | When the Hub authorization redirects back to the admin panel with query params like &install_token and authorization_code, two unguarded array accesses were throwing PHP warnings that Magento captured and displayed as exceptions, breaking the entire Hub integration flow.
| **How?**          | In Controller/Adminhtml/Hub/Index.php the key &install_token was wrong — PHP strips the & separator when parsing query params, so the correct key is install_token. Added ?? null as fallback. In Observer/HubIntegrationObserver.php replaced === null with empty() to safely handle absent keys, and added isset() guard before accessing the nested fields key with an empty array as fallback

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### :package: Attachments (if appropriate)
Add additional informations like screenshots, issue link, etc

<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/dfb0edaf-b451-428b-8e9e-9e9dc6ac9809" />


#### :speech_balloon: Important guidelines

* Add pull request labels.
* Check base branch.
* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
