### PR TITLE
fix: when poiType is null

### DIFF
--- a/Concrete/Magento2CoreSetup.php
+++ b/Concrete/Magento2CoreSetup.php
@@ -371,7 +371,7 @@ final class Magento2CoreSetup extends AbstractModuleCoreSetup
             ScopeInterface::SCOPE_WEBSITES,
             self::getCurrentStoreId()
         );
-        $decoded = json_decode($poiTypeRaw, true);
+        $decoded = $poiTypeRaw !== null ? json_decode($poiTypeRaw, true) : null;  
         $dataObj->poiType = is_array($decoded) ? $decoded : null;
     }
 


### PR DESCRIPTION
Esta solicitação de pull request implementa uma pequena melhoria no método `fillWithHubConfig` em `Magento2CoreSetup.php`. A atualização garante que, se o valor de `$poiTypeRaw` for `null`, ele não será passado para `json_decode`, evitando decodificações desnecessárias e possíveis avisos.

* Melhoria no tratamento de valores nulos para a variável `$poiTypeRaw` no método `fillWithHubConfig` para evitar a decodificação de um valor `null`. (`Concrete/Magento2CoreSetup.php`)