### PR TITLE
chore: add alphanumeric compatibilization

### DIFF
--- a/Concrete/Magento2PlatformOrderDecorator.php
+++ b/Concrete/Magento2PlatformOrderDecorator.php
@@ -582,7 +582,7 @@ class Magento2PlatformOrderDecorator extends AbstractPlatformOrderDecorator
             return '';
         }
         return preg_replace(
-            '/\D/',
+            '/[^a-zA-Z0-9]/',
             '',
             $document
         );

--- a/Gateway/Transaction/Base/ResourceGateway/AbstractRequestDataProvider.php
+++ b/Gateway/Transaction/Base/ResourceGateway/AbstractRequestDataProvider.php
@@ -98,7 +98,7 @@ abstract class AbstractRequestDataProvider
      */
     public function getDocumentType()
     {
-        $identity = (int) preg_replace('/[^0-9]/','', $this->getDocumentNumber() ?? '');
+        $identity = preg_replace('/[^a-zA-Z0-9]/', '', $this->getDocumentNumber() ?? '');
         return (strlen($identity) === 14) ?
             \Pagarme\Pagarme\Model\Enum\DocumentTypeEnum::CNPJ :
             \Pagarme\Pagarme\Model\Enum\DocumentTypeEnum::CPF;

--- a/Helper/ModuleHelper.php
+++ b/Helper/ModuleHelper.php
@@ -67,7 +67,7 @@ class ModuleHelper extends \Magento\Framework\App\Helper\AbstractHelper
         }
 
         if(($format ==  true) and (!is_null($this->taxVat))){
-             $this->taxVat = preg_replace("/[^0-9]/", "", $this->taxVat);
+             $this->taxVat = preg_replace('/[^a-zA-Z0-9]/', '', $this->taxVat);
         }
         return $this->taxVat;
 

--- a/Test/Unit/Model/WebhookManagementTest.php
+++ b/Test/Unit/Model/WebhookManagementTest.php
@@ -68,6 +68,57 @@ class WebhookManagementTest extends BaseTest
     }
 
 
+    public function testSaveWithRecipientWebhookAlphanumericCnpj()
+    {
+        $moduleCoreSetupMock = Mockery::mock('alias:Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup');
+        $moduleCoreSetupMock->shouldReceive('bootstrap')
+            ->andReturnSelf();
+
+        $orderMock = Mockery::mock(Order::class);
+        $orderMock->shouldReceive('loadByIncrementId')
+            ->andReturnSelf();
+        $orderMock->shouldReceive('getId')
+            ->andReturnFalse();
+
+        $orderFactoryMock = Mockery::mock(OrderFactory::class);
+        $orderFactoryMock->shouldReceive('create')
+            ->andReturn($orderMock);
+        $accountMock = Mockery::mock(Account::class);
+
+        $webhookReceiverServiceMock = Mockery::mock(WebhookReceiverService::class);
+        $webhookRecipientResponse = [
+            'message' => 'Recipient updated',
+            'code' => 200
+        ];
+        $webhookReceiverServiceMock->shouldReceive('handle')
+            ->once()
+            ->andReturn($webhookRecipientResponse);
+
+        $webhookManagement = new WebhookManagement($orderFactoryMock, $accountMock, $webhookReceiverServiceMock);
+
+        $id = "hook_aaaaaaaaaaaaaaaa";
+        $type = "recipient.updated";
+        $data = [
+            "id" => 'rp_xxxxxxxxxxxxxxxx',
+            "name" => "Test company",
+            "email" => "test@company.test",
+            "document" => "1A2B3C4D000195",
+            "description" => "Test description",
+            "type" => "company",
+            "payment_mode" => "bank_transfer",
+            "status" => "active",
+            "kyc_details" => ["status" => "approved"],
+        ];
+
+        $account = [
+            "id" => "acc_xxxxxxxxxxxxxxxx",
+            "name" => "Account Test"
+        ];
+        $result = $webhookManagement->save($id, $type, $data, $account);
+
+        $this->assertSame($webhookRecipientResponse, $result);
+    }
+
     public function testSaveWithNonPlatformWebhook()
     {
         $moduleCoreSetupMock = Mockery::mock('alias:Pagarme\Core\Kernel\Abstractions\AbstractModuleCoreSetup');

--- a/view/adminhtml/web/css/pagarme_style.css
+++ b/view/adminhtml/web/css/pagarme_style.css
@@ -24,6 +24,10 @@
     margin-left: 10px;
 }
 
+#pagarme-recipients-form input[data-document-mask] {
+    text-transform: uppercase;
+}
+
 .product_search {
     padding: .6rem 1rem .6rem;
     width: 15%;

--- a/view/adminhtml/web/js/recipients.js
+++ b/view/adminhtml/web/js/recipients.js
@@ -179,7 +179,7 @@ require([
         let value = '';
         if (document) {
             value = 'individual';
-            document = document.toString().replace(/\D/g, '');
+            document = document.toString().replace(/[^a-zA-Z0-9]/g, '');
             if (document.length > 11) {
                 value = 'corporation';
             }
@@ -226,7 +226,7 @@ require([
     }
 
     function getCnpjData(documentNumber) {
-        documentNumber = documentNumber.replace(/\D/g, '');
+        documentNumber = documentNumber.replace(/[^a-zA-Z0-9]/g, '');
         const maxRequests = 3;
         let requests = 0;
         $.ajax({
@@ -745,6 +745,7 @@ require([
         $('[data-date-mask]').mask('00/00/0000');
         $('[data-currency-mask]').mask("#.##0,00", {reverse: true});
         $('[data-zipcode-mask]').mask('00000-000');
+        $('[data-document-mask]').mask(cpfMask).attr('placeholder', cpfMask);
     }
 
     function formatDate(date) {

--- a/view/adminhtml/web/js/recipients.js
+++ b/view/adminhtml/web/js/recipients.js
@@ -68,6 +68,10 @@ require([
             $(this).removeClass('readonly');
         });
 
+        $('[data-document-mask]').on('input', function () {
+            this.value = this.value.toUpperCase();
+        });
+
         $(fieldId['document'])
             .on('keyup change', function () {
                 $(fieldId['holderDocument'])

--- a/view/adminhtml/web/js/recipients.js
+++ b/view/adminhtml/web/js/recipients.js
@@ -11,7 +11,7 @@ require([
     const
         cpfMask = '000.000.000-00',
         cnpjMax = 18, // Includes punctuation due to the mask
-        cnpjMask = '00.000.000/0000-00',
+        cnpjMask = 'AA.AAA.AAA/AAAA-00', // A = alphanumeric; only check digits remain numeric
         errorTitle = $.mage.__('Error!'),
         fieldDataAttr = {
             datepicker: '[data-datepicker]',

--- a/view/frontend/web/css/pagarme_style.css
+++ b/view/frontend/web/css/pagarme_style.css
@@ -23,6 +23,10 @@
     display: none;
 }
 
+.multibuyer_document {
+    text-transform: uppercase;
+}
+
 .field.hidden-element,
 .field-error.hidden-element {
     display: none;

--- a/view/frontend/web/js/core/validators/CustomerValidator.js
+++ b/view/frontend/web/js/core/validators/CustomerValidator.js
@@ -12,7 +12,7 @@ define([], () => {
                 return;
             }
 
-            if (address.vatId <= 0 && address.vatId != null) {
+            if (address.vatId != null && address.vatId.toString().trim() === '') {
                 this.errors.push("O campo CPF/CNPJ é obrigatório.");
             }
 

--- a/view/frontend/web/template/payment/multibuyer-form.html
+++ b/view/frontend/web/template/payment/multibuyer-form.html
@@ -84,7 +84,7 @@
         <span><!-- ko i18n: 'Document'--><!-- /ko --></span>
     </label>
     <div class="control">
-        <input type="text" class="input-text multibuyer_document" name="payment[multibuyer_document]" maxlength="16">
+        <input type="text" class="input-text multibuyer_document" name="payment[multibuyer_document]" maxlength="16" oninput="this.value = this.value.toUpperCase()">
     </div>
     <div class="field-error hidden-element">
         <span ><!-- ko i18n: 'This is a required field'--><!-- /ko --></span>


### PR DESCRIPTION
Esta solicitação de pull introduz suporte para valores alfanuméricos no CNPJ (Cadastro Nacional da Pessoa Jurídica) em todo o código-fonte, garantindo que os campos do documento agora aceitem e processem letras e números, e que a entrada do usuário seja convertida consistentemente para maiúsculas. Também aprimora a validação e o tratamento de entrada para campos de documento nas interfaces administrativa e de front-end. As alterações mais importantes estão resumidas abaixo.

### Atualizações de Back-end e Validação

* Atualizada toda a lógica de sanitização de documentos (PHP) para permitir caracteres alfanuméricos, substituindo padrões de regex que anteriormente removiam caracteres não numéricos por padrões que agora retêm letras e números (por exemplo, `/\D/` → `/[^a-zA-Z0-9]/`) em métodos como `cleanCustomerDocument`, `getDocumentType` e `setTaxVat`. [[1]](diffhunk://#diff-060c6a02a76520e88353cecb46671c06fe110d8fbfed4e96132ad5277470867cL585-R585) [[2]](diffhunk://#diff-f094d9a024e20d7262e4a0bbea61fc29edfc827a5fc87b0ed4f93e6503f89697L101-R101) [[3]](diffhunk://#diff-0362ba381cb94eba8bf0a920160e871ec226b76eae72080104cf3a9cce2fbd0aL70-R70)
* Melhoramos a validação do número de identificação fiscal (CNPJ) do cliente para garantir que o campo seja obrigatório apenas quando não for nulo e vazio, corrigindo um erro de lógica em `CustomerValidator.js`.

### Manipulação de Entrada no Frontend

* Modificamos os campos de entrada de documentos nas interfaces administrativa e do frontend para converter automaticamente a entrada para maiúsculas, inclusive por meio de manipuladores de eventos JavaScript e adicionando regras CSS `text-transform: uppercase`. [[1]](diffhunk://#diff-1d1ff4081bed165671536392252142617ee8f56505f31f5a293bddaa4e97bba5R27-R30) [[2]](diffhunk://#diff-bb4dbd5a2680b6af4ca9ebab4b2b1f6332c5f843757d41406f620b85a802c5f5R26-R29) [[3]](diffhunk://#diff-0433b25a82d31396d5beeaa0e63da02bc4a4c26061d8c83094ec48734b0b5b76L87-R87) [[4]](diffhunk://#diff-15380e49f91fbef0ed4a05fc8190b65395089e7c2399d5fc970a9ae230e4bb6eR71-R74)
* A máscara de entrada do CNPJ no JS do administrador foi atualizada para permitir caracteres alfanuméricos (a máscara foi alterada de `00.000.000/0000-00` para `AA.AAA.AAA/AAAA-00`).

### Atualizações da Lógica JavaScript

* Toda a lógica JS que remove caracteres não numéricos dos valores do documento foi ajustada para agora reter os alfanuméricos, garantindo o processamento e a validação corretos do documento (por exemplo, ao determinar se um documento é um CNPJ ou CPF e ao fazer solicitações AJAX para dados do CNPJ). [[1]](diffhunk://#diff-15380e49f91fbef0ed4a05fc8190b65395089e7c2399d5fc970a9ae230e4bb6eL178-R182) [[2]](diffhunk://#diff-15380e49f91fbef0ed4a05fc8190b65395089e7c2399d5fc970a9ae230e4bb6eL225-R229)
* Garantimos que os campos de entrada de documentos na interface administrativa estejam mascarados e possuam marcadores apropriados para os formatos CPF/CNPJ.

### Testes
<details><summary>Criando recebedor</summary>


<img width="1147" height="968" alt="image" src="https://github.com/user-attachments/assets/16744979-aafe-4cc6-982a-ae11eecc7be8" />


</details> 

<details><summary>Recebedor criado</summary>


<img width="1920" height="968" alt="image" src="https://github.com/user-attachments/assets/4ed626e6-be07-4970-9753-4f3f4d299937" />



</details> 

### Testes

* Adicionamos um novo teste unitário para verificar se os webhooks com documentos CNPJ alfanuméricos são processados ​​corretamente, garantindo a compatibilidade do backend com o novo formato de documento.