### PR TITLE
chore: update versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,12 @@
 {
     "name": "pagarme/pagarme-magento2-module",
     "license": "MIT",
-    "version": "2.9.0",
+    "version": "2.10.0",
     "type": "magento2-module",
     "description": "Magento 2 Module Pagar.me",
-    "minimum-stability": "dev",
     "require": {
         "php": ">=7.1",
-        "pagarme/ecommerce-module-core": "~2.10.0"
+        "pagarme/ecommerce-module-core": "~2.11.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -9,7 +9,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Pagarme_Pagarme" setup_version="2.9.0">
+    <module name="Pagarme_Pagarme" setup_version="2.10.0">
         <sequence>
             <module name="Magento_Sales" />
             <module name="Magento_Payment" />


### PR DESCRIPTION
This pull request updates the Pagar.me Magento 2 module to version 2.10.0. The main changes are version bumps to both the module itself and its core dependency.

Version updates:

* Updated the module version to `2.10.0` in both `composer.json` and `etc/module.xml` to reflect the new release. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L4-R9) [[2]](diffhunk://#diff-cfc6d0cac6c218df3440a678610688f93f9628a67a457c49030a50f4e7fc50d5L12-R12)
* Increased the required version of `pagarme/ecommerce-module-core` to `~2.11.0` in `composer.json` to ensure compatibility with the latest core features and fixes.