### PR TITLE
2.10.0 patch

### DIFF
--- a/Concrete/Magento2DatabaseDecorator.php
+++ b/Concrete/Magento2DatabaseDecorator.php
@@ -91,8 +91,7 @@ final class Magento2DatabaseDecorator extends AbstractDatabaseDecorator
 
     protected function doFetch($query)
     {
-        $connection = $this->db->getConnection();
-
+        $connection = $this->db->getConnection(\Magento\Framework\App\ResourceConnection::DEFAULT_CONNECTION);
         return $connection->fetchAll($query);
     }
 

--- a/Concrete/Magento2DatabaseDecorator.php
+++ b/Concrete/Magento2DatabaseDecorator.php
@@ -72,7 +72,7 @@ final class Magento2DatabaseDecorator extends AbstractDatabaseDecorator
 
     protected function doQuery($query)
     {
-        $connection = $this->db->getConnection();
+        $connection = $this->db->getConnection(\Magento\Framework\App\ResourceConnection::DEFAULT_CONNECTION);
         $connection->query($query);
         $this->setLastInsertId($connection->lastInsertId());
     }

--- a/Model/Api/ProductsSubscription.php
+++ b/Model/Api/ProductsSubscription.php
@@ -95,18 +95,20 @@ class ProductsSubscription implements ProductSubscriptionApiInterface
                 }
             }
 
-            $saved = $this->productSubscriptionService
-                ->saveProductSubscription($aggregate);
+            $saved = $this->productSubscriptionService->saveProductSubscription($aggregate);
+
+            if ($saved && $saved->getId()) {
+                $saved = $this->productSubscriptionService->findById($saved->getId());
+            }
 
             $this->productSubscriptionHelper->setCustomOption($saved);
+            return $saved;
         } catch (Throwable $exception) {
             return [
                 'code' => 404,
                 'message' => $exception->getMessage()
             ];
         }
-
-        return $saved;
     }
 
     /**

--- a/Model/Api/ProductsSubscription.php
+++ b/Model/Api/ProductsSubscription.php
@@ -65,7 +65,6 @@ class ProductsSubscription implements ProductSubscriptionApiInterface
                 if (empty($product)) {
                     return __(self::SUBSCRIPTION_NOT_FOUND_MESSAGE);
                 }
-
                 $productSubscription->setId($id);
             }
 
@@ -73,12 +72,33 @@ class ProductsSubscription implements ProductSubscriptionApiInterface
                 $productSubscription->getProductId()
             );
 
-            $productSubscription = $this->productSubscriptionService
-                ->saveProductSubscription($productSubscription);
+            // Converte o Mapper (DTO do Magento) para o Aggregate do core
+            $aggregate = new \Pagarme\Core\Recurrence\Aggregates\ProductSubscription();
+            $aggregate->setProductId($productSubscription->getProductId());
+            $aggregate->setCreditCard($productSubscription->getCreditCard());
+            $aggregate->setBoleto($productSubscription->getBoleto());
+            $aggregate->setAllowInstallments($productSubscription->getAllowInstallments());
+            $aggregate->setSellAsNormalProduct($productSubscription->getSellAsNormalProduct());
 
-            $this->productSubscriptionHelper
-                ->setCustomOption($productSubscription);
+            if ($productSubscription->getId()) {
+                $aggregate->setId($productSubscription->getId());
+            }
 
+            if ($productSubscription->getRepetitions()) {
+                foreach ($productSubscription->getRepetitions() as $rep) {
+                    $repetition = new \Pagarme\Core\Recurrence\Aggregates\Repetition();
+                    $repetition->setInterval($rep->getInterval());
+                    $repetition->setIntervalCount($rep->getIntervalCount());
+                    $repetition->setRecurrencePrice($rep->getRecurrencePrice());
+                    $repetition->setCycles($rep->getCycles());
+                    $aggregate->addRepetition($repetition);
+                }
+            }
+
+            $saved = $this->productSubscriptionService
+                ->saveProductSubscription($aggregate);
+
+            $this->productSubscriptionHelper->setCustomOption($saved);
         } catch (Throwable $exception) {
             return [
                 'code' => 404,
@@ -86,7 +106,7 @@ class ProductsSubscription implements ProductSubscriptionApiInterface
             ];
         }
 
-        return $productSubscription;
+        return $saved;
     }
 
     /**
@@ -192,7 +212,6 @@ class ProductsSubscription implements ProductSubscriptionApiInterface
                 'code' => 200,
                 'message' => __('Subscription product saved')
             ]);
-
         } catch (Throwable $exception) {
             return json_encode([
                 'code' => 404,

--- a/Model/ObjectMapper/ProductSubscription/ProductSubscriptionMapper.php
+++ b/Model/ObjectMapper/ProductSubscription/ProductSubscriptionMapper.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Pagarme\Pagarme\Model\ObjectMapper\ProductSubscription;
+
+use Pagarme\Pagarme\Api\ObjectMapper\ProductSubscription\ProductSubscriptionMapperInterface;
+
+class ProductSubscriptionMapper implements ProductSubscriptionMapperInterface
+{
+  /** @var int|null */
+  protected $id;
+
+  /** @var int|null */
+  protected $productId;
+
+  /** @var bool */
+  protected $creditCard = false;
+
+  /** @var bool */
+  protected $boleto = false;
+
+  /** @var bool */
+  protected $allowInstallments = false;
+
+  /** @var bool */
+  protected $sellAsNormalProduct = false;
+
+  /** @var \Pagarme\Pagarme\Api\ObjectMapper\ProductSubscription\RepetitionInterface[]|null */
+  protected $repetitions;
+
+  /** @var \DateTime|null */
+  protected $createdAt;
+
+  /** @var \DateTime|null */
+  protected $updatedAt;
+
+  public function getId()
+  {
+    return $this->id;
+  }
+
+  public function setId($id)
+  {
+    $this->id = $id;
+    return $this;
+  }
+
+  public function getProductId()
+  {
+    return $this->productId;
+  }
+
+  public function setProductId($productId)
+  {
+    $this->productId = $productId;
+    return $this;
+  }
+
+  public function getCreditCard()
+  {
+    return $this->creditCard;
+  }
+
+  public function setCreditCard($creditCard)
+  {
+    $this->creditCard = (bool) $creditCard;
+    return $this;
+  }
+
+  public function getBoleto()
+  {
+    return $this->boleto;
+  }
+
+  public function setBoleto($boleto)
+  {
+    $this->boleto = (bool) $boleto;
+    return $this;
+  }
+
+  public function getAllowInstallments()
+  {
+    return $this->allowInstallments;
+  }
+
+  public function setAllowInstallments($installments)
+  {
+    $this->allowInstallments = (bool) $installments;
+    return $this;
+  }
+
+  public function getRepetitions()
+  {
+    return $this->repetitions;
+  }
+
+  public function setRepetitions(array $repetitions)
+  {
+    $this->repetitions = $repetitions;
+    return $this;
+  }
+
+  public function getSellAsNormalProduct()
+  {
+    return $this->sellAsNormalProduct;
+  }
+
+  public function setSellAsNormalProduct($sellAsNormalProduct)
+  {
+    $this->sellAsNormalProduct = (bool) $sellAsNormalProduct;
+    return $this;
+  }
+
+  public function getCreatedAt()
+  {
+    return $this->createdAt;
+  }
+
+  public function setCreatedAt(\DateTime $createdAt)
+  {
+    $this->createdAt = $createdAt;
+    return $this;
+  }
+
+  public function getUpdatedAt()
+  {
+    return $this->updatedAt;
+  }
+
+  public function setUpdatedAt(\DateTime $updatedAt)
+  {
+    $this->updatedAt = $updatedAt;
+    return $this;
+  }
+}

--- a/Model/ObjectMapper/ProductSubscription/Repetition.php
+++ b/Model/ObjectMapper/ProductSubscription/Repetition.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Pagarme\Pagarme\Model\ObjectMapper\ProductSubscription;
+
+use Pagarme\Pagarme\Api\ObjectMapper\ProductSubscription\RepetitionInterface;
+
+class Repetition implements RepetitionInterface
+{
+  private $id;
+  private $subscriptionId;
+  private $interval;
+  private $intervalCount;
+  private $recurrencePrice;
+  private $cycles;
+  private $createdAt;
+  private $updatedAt;
+
+  public function getId()
+  {
+    return $this->id;
+  }
+
+  public function setId($id)
+  {
+    $this->id = $id;
+    return $this;
+  }
+
+  public function getSubscriptionId()
+  {
+    return $this->subscriptionId;
+  }
+
+  public function setSubscriptionId($subscriptionId)
+  {
+    $this->subscriptionId = $subscriptionId;
+    return $this;
+  }
+
+  public function getInterval()
+  {
+    return $this->interval;
+  }
+
+  public function setInterval($interval)
+  {
+    $this->interval = $interval;
+    return $this;
+  }
+
+  public function getIntervalCount()
+  {
+    return $this->intervalCount;
+  }
+
+  public function setIntervalCount($intervalCount)
+  {
+    $this->intervalCount = $intervalCount;
+    return $this;
+  }
+
+  public function getRecurrencePrice()
+  {
+    return $this->recurrencePrice;
+  }
+
+  public function setRecurrencePrice($recurrencePrice)
+  {
+    $this->recurrencePrice = $recurrencePrice;
+    return $this;
+  }
+
+  public function getCycles()
+  {
+    return $this->cycles;
+  }
+
+  public function setCycles($cycles)
+  {
+    $this->cycles = $cycles;
+    return $this;
+  }
+
+  public function getCreatedAt()
+  {
+    return $this->createdAt;
+  }
+
+  public function setCreatedAt(\DateTime $createdAt)
+  {
+    $this->createdAt = $createdAt;
+    return $this;
+  }
+
+  public function getUpdatedAt()
+  {
+    return $this->updatedAt;
+  }
+
+  public function setUpdatedAt(\DateTime $updatedAt)
+  {
+    $this->updatedAt = $updatedAt;
+    return $this;
+  }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -34,6 +34,9 @@
     <preference for="Pagarme\Pagarme\Api\MaintenanceInterface"
                 type="Pagarme\Pagarme\Model\Maintenance"/>
 
+    <preference for="Pagarme\Pagarme\Api\ObjectMapper\ProductSubscription\ProductSubscriptionMapperInterface"
+                type="Pagarme\Pagarme\Model\ObjectMapper\ProductSubscription\ProductSubscriptionMapper"/>
+
     <preference for="Pagarme\Pagarme\Api\ProductSubscriptionInterface"
                 type="Pagarme\Pagarme\Model\Api\ProductsSubscription"/>
 
@@ -785,6 +788,7 @@
     <preference for="Pagarme\Pagarme\Api\RecurrenceProductsSubscriptionRepositoryInterface" type="Pagarme\Pagarme\Model\RecurrenceProductsSubscriptionRepository"/>
     <preference for="Pagarme\Pagarme\Api\Data\RecurrenceProductsSubscriptionInterface" type="Pagarme\Pagarme\Model\RecurrenceProductsSubscription"/>
     <preference for="Pagarme\Pagarme\Api\Data\RecurrenceProductsSubscriptionSearchResultsInterface" type="Magento\Framework\Api\SearchResults"/>
+    <preference for="Pagarme\Pagarme\Api\ObjectMapper\ProductSubscription\RepetitionInterface" type="Pagarme\Pagarme\Model\ObjectMapper\ProductSubscription\Repetition"/>
     <preference for="Pagarme\Pagarme\Api\RecurrenceSubscriptionRepetitionsRepositoryInterface" type="Pagarme\Pagarme\Model\RecurrenceSubscriptionRepetitionsRepository"/>
     <preference for="Pagarme\Pagarme\Api\Data\RecurrenceSubscriptionRepetitionsInterface" type="Pagarme\Pagarme\Model\RecurrenceSubscriptionRepetitions"/>
     <preference for="Pagarme\Pagarme\Api\Data\RecurrenceSubscriptionRepetitionsSearchResultsInterface" type="Magento\Framework\Api\SearchResults"/>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://github.com/pagarme/magento2/issues/430
| **What?**         | Corrigida a injeção de dependência da interface ProductSubscriptionMapperInterface para os endpoints de criação e atualização de recorrência de produto.
| **Why?**          | Os endpoints POST /V1/pagarme/recurrence/product e PUT /V1/pagarme/recurrence/product/:id estavam quebrando com um erro fatal (critical), pois o Magento não conseguia instanciar a interface do mapeador por falta de uma preferência configurada no di.xml.
| **How?**          | Foi adicionada a regra de <preference> mapeando a interface ProductSubscriptionMapperInterface para a sua respectiva classe concreta no arquivo de configuração di.xml do módulo.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### :package: Attachments (if appropriate)
Add additional informations like screenshots, issue link, etc

#### :speech_balloon: Important guidelines

* Add pull request labels.
* Check base branch.
* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
