### PR TITLE
chore: remove one stone urls

### DIFF
--- a/Block/Adminhtml/System/Config/Form/Field/HubIntegration.php
+++ b/Block/Adminhtml/System/Config/Form/Field/HubIntegration.php
@@ -102,20 +102,20 @@ class HubIntegration extends Field
     private function getBaseIntegrateUrl(): string
     {
         $baseUrl = sprintf(
-            'https://hub.stone.com.br/redirect-onestone/#/?q=/apps/%s/authorize',
+            'https://hub.pagar.me/apps/%s/authorize',
             $this->getPublicAppKey()
         );
 
         if($this->getRequest()->getParam('website') !== null) {
             $params = sprintf(
-                '&redirect=%swebsite/%s/install_token/%s',
+                '?redirect=%swebsite/%s/install_token/%s',
                 $this->getRedirectUrl(),
                 Magento2CoreSetup::getCurrentStoreId(),
                 $this->getInstallToken()
             );
         } else {
             $params = sprintf(
-                '&redirect=%sinstall_token/%s',
+                '?redirect=%sinstall_token/%s',
                 $this->getRedirectUrl(),
                 $this->getInstallToken()
             );
@@ -131,7 +131,7 @@ class HubIntegration extends Field
     private function getBaseViewIntegrationUrl($installId): string
     {
         return sprintf(
-            'https://hub.stone.com.br/redirect-onestone/#/?q=/apps/%s/edit/%s',
+            'https://hub.pagar.me/apps/%s/edit/%s',
             $this->getPublicAppKey(),
             $installId
         );

--- a/etc/adminhtml/system/transaction/googlepay.xml
+++ b/etc/adminhtml/system/transaction/googlepay.xml
@@ -16,7 +16,7 @@
         </field>
         <field id="pagarme_account_id" type="text" sortOrder="30" showInWebsite="1" showInStore="1" showInDefault="1" translate="label, comment">
             <label>Stone account ID</label>
-            <comment><![CDATA[Consult the <a target='_blank' href='https://hub.stone.com.br/redirect-onestone/'>Dashboard</a> at: <i>Settings > Keys > Account ID</i>]]></comment>
+            <comment><![CDATA[Consult the <a target='_blank' href='https://id.pagar.me/signin'>Dashboard</a> at: <i>Settings > Keys > Account ID</i>]]></comment>
             <config_path>pagarme_pagarme/hub/account_id</config_path>
             <depends>
                 <field id="active">1</field>


### PR DESCRIPTION
| Questions | Answers |
| ------------- | ------------------------------------------------------- |
| **Issue** | https://mundipagg.atlassian.net/browse/MC-{ISSUE-NUMBER} |
| **What?** | Reverted Hub integration and authentication URLs back to original Pagar.me endpoints, removing `hub.stone.com.br` (OneStone) references. |
| **Why?** | To ensure the extension maintains fully functional integration flows with Pagar.me Hub while restricting the current release scope strictly to visual/branding updates. |
| **How?** | <ul><li>Restored `https://hub.pagar.me/apps/%s/authorize` and `https://hub.pagar.me/apps/%s/edit/%s` base URLs in `HubIntegration.php`.</li><li>Reverted query parameters syntax (`?redirect=...` instead of `&redirect=...`) for authentication flows.</li><li>Updated dashboard reference link in `googlepay.xml` back to `https://id.pagar.me/signin`.</li></ul> |

#### :package: Attachments (if appropriate)
* **Related PR:** #443 (Merge master OneStone)
* **Affected Files:**
  * `Block/Adminhtml/System/Config/Form/Field/HubIntegration.php`
  * `etc/adminhtml/system/transaction/googlepay.xml`

#### :speech_balloon: Important guidelines

* Add pull request labels.
* Check base branch.
* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!

https://allstone.atlassian.net/browse/HPIP-430